### PR TITLE
Update manager.py

### DIFF
--- a/xcoll/manager.py
+++ b/xcoll/manager.py
@@ -839,7 +839,7 @@ class CollimatorManager:
                 }
                 ,
                 'aperture': {
-                    's':    aper_s,
+                    's':    [s for s in aper_s],
                     'name': aper_names,
                     'n':    aper_nabs
                 }

--- a/xcoll/manager.py
+++ b/xcoll/manager.py
@@ -839,7 +839,7 @@ class CollimatorManager:
                 }
                 ,
                 'aperture': {
-                    's':    [s for s in aper_s],
+                    's':    aper_s,
                     'name': aper_names,
                     'n':    aper_nabs
                 }
@@ -853,7 +853,7 @@ class CollimatorManager:
 
         if file is not None:
             with open(Path(file), 'w') as fid:
-                json.dump(self._lossmap, fid, indent=True)
+                json.dump(self._lossmap, fid, indent=True, cls=xo.JEncoder)
     
         return self._lossmap
 


### PR DESCRIPTION
fixed bug in saving to json converting numpy array to list

previous error message:
  File     coll_manager.lossmap(part, file='lossmap.dat')
[...]
TypeError: Object of type ndarray is not JSON serializable
