### PR TITLE
Release 0.3.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xcoll"
-version = "0.3.1"
+version = "0.3.2"
 description = "Xsuite collimation package"
 homepage = "https://github.com/xsuite/xcoll"
 repository = "https://github.com/xsuite/xcoll"

--- a/tests/test__regenerate_kernels.py
+++ b/tests/test__regenerate_kernels.py
@@ -1,0 +1,6 @@
+import xtrack as xt
+
+def test_init():
+    xt.prebuild_kernels.regenerate_kernels(kernels=[
+        "default_xcoll_only_absorbers", "default_xcoll",
+        "default_xcoll_crystals"])

--- a/tests/test__regenerate_kernels.py
+++ b/tests/test__regenerate_kernels.py
@@ -1,6 +1,7 @@
 import xtrack as xt
 
 def test_init():
-    xt.prebuild_kernels.regenerate_kernels(kernels=[
-        "default_xcoll_only_absorbers", "default_xcoll",
-        "default_xcoll_crystals"])
+    from xtrack.prebuilt_kernels.kernel_definitions import kernel_definitions
+    xcoll_kernels = [ker for ker in kernel_definitions if 'xcoll' in ker]
+    if len(xcoll_kernels) > 0:
+        xt.prebuild_kernels.regenerate_kernels(kernels=xcoll_kernels)

--- a/tests/test_rf_sweep.py
+++ b/tests/test_rf_sweep.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import numpy as np
+import pytest
+
 import xtrack as xt
 import xcoll as xc
 from xobjects.test_helpers import for_all_test_contexts
@@ -7,11 +9,12 @@ from xobjects.test_helpers import for_all_test_contexts
 path = Path(__file__).parent / 'data'
 
 @for_all_test_contexts
-def test_dp_pos(test_context):
-    sweep = -300   # negative sweep => positive off-momentum
+@pytest.mark.parametrize("sweep, beam", [[-300, 1], [300, 2]],
+                         ids=["DP pos", "DP neg"])
+def test_rf_sweep(sweep, beam, test_context):
     num_turns = 6000
     num_particles = 5
-    line = xt.Line.from_json(path / f'sequence_lhc_run3_b1.json')
+    line = xt.Line.from_json(path / f'sequence_lhc_run3_b{beam}.json')
 
     line.build_tracker()
 
@@ -21,22 +24,9 @@ def test_dp_pos(test_context):
     rf_sweep = xc.RFSweep(line)
     # This sweep is 3.5 buckets, so check that all particles are at least 3 buckets away
     rf_sweep.track(sweep=sweep, num_turns=num_turns, particles=part)
-    assert np.all(part.delta > 1.5e-3)
 
-
-@for_all_test_contexts
-def test_dp_neg(test_context):
-    sweep = 300   # positive sweep => negative off-momentum
-    num_turns = 6000
-    num_particles = 5
-    line = xt.Line.from_json(path / f'sequence_lhc_run3_b2.json')
-
-    line.build_tracker()
-
-    part = line.build_particles(delta=np.linspace(-2e-4, 2e-4, num_particles),
-                                x_norm=0, px_norm=0, y_norm=0, py_norm=0)
-
-    rf_sweep = xc.RFSweep(line)
-    # This sweep is 3.5 buckets, so check that all particles are at least 3 buckets away
-    rf_sweep.track(sweep=sweep, num_turns=num_turns, particles=part)
-    assert np.all(part.delta < -1.5e-3)
+    # negative sweep => positive off-momentum etc
+    if sweep < 0:
+        assert np.all(part.delta > 1.5e-3)
+    else:
+        assert np.all(part.delta < -1.5e-3)

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,5 +1,5 @@
 from xcoll import __version__
 
 def test_version():
-    assert __version__ == '0.3.1'
+    assert __version__ == '0.3.2'
 

--- a/xcoll/__init__.py
+++ b/xcoll/__init__.py
@@ -3,7 +3,7 @@
 # Copyright (c) CERN, 2023.                 #
 # ######################################### #
 
-from .general import _pkg_root, __version__
+from .general import _pkg_root, __version__, citation
 
 from .beam_elements import BlackAbsorber, EverestBlock, EverestCollimator, EverestCrystal
 from .scattering_routines.everest import materials, Material, CrystalMaterial
@@ -11,3 +11,5 @@ from .manager import CollimatorManager
 from .colldb import CollimatorDatabase, load_SixTrack_colldb
 from .rf_sweep import RFSweep
 
+# print("If you use Xcoll in your simulations, please cite us :-)")
+# print(citation)

--- a/xcoll/__init__.py
+++ b/xcoll/__init__.py
@@ -5,7 +5,7 @@
 
 from .general import _pkg_root, __version__, citation
 
-from .beam_elements import BlackAbsorber, EverestBlock, EverestCollimator, EverestCrystal
+from .beam_elements import BlackAbsorber, EverestBlock, EverestCollimator, EverestCrystal, element_classes
 from .scattering_routines.everest import materials, Material, CrystalMaterial
 from .manager import CollimatorManager
 from .colldb import CollimatorDatabase, load_SixTrack_colldb

--- a/xcoll/beam_elements/__init__.py
+++ b/xcoll/beam_elements/__init__.py
@@ -3,3 +3,9 @@ from .absorber import BlackAbsorber
 from .everest import EverestBlock, EverestCollimator, EverestCrystal
 
 _all_collimator_types = {BlackAbsorber, EverestCollimator, EverestCrystal}
+
+block_classes = tuple(v for v in globals().values()
+                      if isinstance(v, type) and issubclass(v, BaseBlock) and v != BaseBlock)
+collimator_classes = tuple(v for v in globals().values()
+                           if isinstance(v, type) and issubclass(v, BaseCollimator) and v != BaseCollimator)
+element_classes = block_classes + collimator_classes

--- a/xcoll/beam_elements/base.py
+++ b/xcoll/beam_elements/base.py
@@ -1,5 +1,5 @@
 # copyright ############################### #
-# This file is part of the Xcoll Package.  #
+# This file is part of the Xcoll Package.   #
 # Copyright (c) CERN, 2023.                 #
 # ######################################### #
 
@@ -20,6 +20,7 @@ class InvalidXcoll(xt.BeamElement):
 
     isthick = True
     behaves_like_drift = True
+#     allow_track = False   # Need to wait for xtrack release to implement
     skip_in_loss_location_refinement = True
     allow_backtrack = True
 
@@ -47,6 +48,7 @@ class BaseBlock(xt.BeamElement):
 
     isthick = True
     behaves_like_drift = True
+#     allow_track = False   # Need to wait for xtrack release to implement
     skip_in_loss_location_refinement = True
 
     _extra_c_sources = [
@@ -88,6 +90,7 @@ class BaseCollimator(xt.BeamElement):
 
     isthick = True
     behaves_like_drift = True
+#     allow_track = False   # Need to wait for xtrack release to implement
     skip_in_loss_location_refinement = True
 
     _skip_in_to_dict  = ['jaw_L', 'jaw_R', 'ref_x', 'ref_y',

--- a/xcoll/beam_elements/collimators_src/everest_block.h
+++ b/xcoll/beam_elements/collimators_src/everest_block.h
@@ -10,11 +10,12 @@
 
 
 /*gpufun*/
-void EverestBlock_set_material(EverestBlockData el, LocalParticle* part0){
+void EverestBlock_set_material(EverestBlockData el){
     MaterialData material = EverestBlockData_getp__material(el);
     RandomRutherfordData rng = EverestBlockData_getp_rutherford_rng(el);
     RandomRutherford_set_by_xcoll_material(rng, (GeneralMaterialData) material);
 }
+
 
 /*gpufun*/
 EverestCollData EverestBlock_init(EverestBlockData el, LocalParticle* part0, int8_t active){
@@ -62,6 +63,7 @@ EverestData EverestBlock_init_data(LocalParticle* part, EverestCollData coll){
 #endif
     return everest;
 }
+
 
 /*gpufun*/
 void EverestBlock_track_local_particle(EverestBlockData el, LocalParticle* part0) {

--- a/xcoll/beam_elements/collimators_src/everest_collimator.h
+++ b/xcoll/beam_elements/collimators_src/everest_collimator.h
@@ -36,6 +36,7 @@ EverestCollData EverestCollimator_init(EverestCollimatorData el, LocalParticle* 
         coll->csref[0] = MaterialData_get_cross_section(material, 0);
         coll->csref[1] = MaterialData_get_cross_section(material, 1);
         coll->csref[5] = MaterialData_get_cross_section(material, 5);
+        coll->only_mcs = MaterialData_get__only_mcs(material);
 
         // Impact table
         coll->record = EverestCollimatorData_getp_internal_record(el, part0);

--- a/xcoll/beam_elements/collimators_src/everest_collimator.h
+++ b/xcoll/beam_elements/collimators_src/everest_collimator.h
@@ -9,8 +9,7 @@
 #include <stdio.h>
 
 
-/*gpufun*/
-void EverestCollimator_set_material(EverestCollimatorData el, LocalParticle* part0){
+void EverestCollimator_set_material(EverestCollimatorData el){
     MaterialData material = EverestCollimatorData_getp__material(el);
     RandomRutherfordData rng = EverestCollimatorData_getp_rutherford_rng(el);
     RandomRutherford_set_by_xcoll_material(rng, (GeneralMaterialData) material);

--- a/xcoll/beam_elements/collimators_src/everest_collimator.h
+++ b/xcoll/beam_elements/collimators_src/everest_collimator.h
@@ -93,8 +93,8 @@ void EverestCollimator_track_local_particle(EverestCollimatorData el, LocalParti
     double const sin_zR     = EverestCollimatorData_get_sin_zR(el);
     double const cos_zR     = EverestCollimatorData_get_cos_zR(el);
     if (fabs(sin_zL-sin_zR) > 1.e-10 || fabs(cos_zL-cos_zR) > 1.e-10 ){
-        printf("Jaws with different angles not yet implemented!");
-        fflush(stdout);
+        printf("Jaws with different angles not yet implemented!");  //only_for_context cpu_serial
+        fflush(stdout);                                             //only_for_context cpu_serial
         kill_all_particles(part0, XC_ERR_NOT_IMPLEMENTED);
     };
 

--- a/xcoll/beam_elements/collimators_src/everest_crystal.h
+++ b/xcoll/beam_elements/collimators_src/everest_crystal.h
@@ -9,9 +9,8 @@
 #include <stdio.h>
 
 
-
 /*gpufun*/
-void EverestCrystal_set_material(EverestCrystalData el, LocalParticle* part0){
+void EverestCrystal_set_material(EverestCrystalData el){
     CrystalMaterialData material = EverestCrystalData_getp__material(el);
     RandomRutherfordData rng = EverestCrystalData_getp_rutherford_rng(el);
     RandomRutherford_set_by_xcoll_material(rng, (GeneralMaterialData) material);

--- a/xcoll/beam_elements/everest.py
+++ b/xcoll/beam_elements/everest.py
@@ -28,8 +28,7 @@ class EverestBlock(BaseBlock):
     _xofields = { **BaseBlock._xofields,
         '_material':        Material,
         'rutherford_rng':   xt.RandomRutherford,
-        '_tracking':        xo.Int8,
-        '_only_mcs':        xo.Int8
+        '_tracking':        xo.Int8
     }
 
     isthick = True
@@ -64,15 +63,6 @@ class EverestBlock(BaseBlock):
                 or mat['__class__'] != "Material":
                     raise ValueError("Invalid material!")
             kwargs['_material'] = mat
-            # TODO: this should be better
-            if np.allclose(mat.Z, 0.) or np.allclose(mat.A, 0.) \
-            or np.allclose(mat.density, 0.) \
-            or np.allclose(mat.excitation_energy, 0.) \
-            or np.allclose(mat.nuclear_radius, 0.) \
-            or np.allclose(mat.nuclear_elastic_slope, 0.):
-                kwargs['_only_mcs'] = True
-            else:
-                kwargs['_only_mcs'] = False
             kwargs.setdefault('rutherford_rng', xt.RandomRutherford())
             kwargs.setdefault('_tracking', True)
         super().__init__(**kwargs)

--- a/xcoll/beam_elements/everest.py
+++ b/xcoll/beam_elements/everest.py
@@ -45,10 +45,10 @@ class EverestBlock(BaseBlock):
         _pkg_root.joinpath('beam_elements','collimators_src','everest_block.h')
     ]
 
-    _per_particle_kernels = {
-        '_EverestBlock_set_material': xo.Kernel(
+    _kernels = {
+        'EverestBlock_set_material': xo.Kernel(
                 c_name='EverestBlock_set_material',
-                args=[]
+                args=[xo.Arg(xo.ThisClass, name='el')]
             )
         }
 
@@ -65,9 +65,14 @@ class EverestBlock(BaseBlock):
             kwargs['_material'] = mat
             kwargs.setdefault('rutherford_rng', xt.RandomRutherford())
             kwargs.setdefault('_tracking', True)
+            use_prebuilt_kernels = kwargs.pop('use_prebuilt_kernels', True)
         super().__init__(**kwargs)
         if '_xobject' not in kwargs:
-            self._EverestBlock_set_material(xp.Particles())
+            self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
+                                 particles_class=xp.Particles,
+                                 only_if_needed=True)
+            self._context.kernels.EverestBlock_set_material(el=self)
+
 
     @property
     def material(self):
@@ -78,8 +83,10 @@ class EverestBlock(BaseBlock):
         if not isinstance(material, Material):
             if not isinstance('material', dict) or material['__class__'] != "Material":
                 raise ValueError("Invalid material!")
-        self._material = material
-        self._EverestBlock_set_material(xp.Particles())
+        if not xt.line._dicts_equal(self.material.to_dict(), material.to_dict()):
+            self._material = material
+            self.compile_kernels(particles_class=xp.Particles, only_if_needed=True)
+            self._context.kernels.EverestBlock_set_material(el=self)
 
     def get_backtrack_element(self, _context=None, _buffer=None, _offset=None):
         return InvalidXcoll(length=-self.length, _context=_context,
@@ -107,10 +114,10 @@ class EverestCollimator(BaseCollimator):
         _pkg_root.joinpath('beam_elements','collimators_src','everest_collimator.h')
     ]
 
-    _per_particle_kernels = {
-        '_EverestCollimator_set_material': xo.Kernel(
+    _kernels = {
+        'EverestCollimator_set_material': xo.Kernel(
                 c_name='EverestCollimator_set_material',
-                args=[]
+                args=[xo.Arg(xo.ThisClass, name='el')]
             )
         }
 
@@ -126,9 +133,13 @@ class EverestCollimator(BaseCollimator):
             kwargs['_material'] = kwargs.pop('material')
             kwargs.setdefault('rutherford_rng', xt.RandomRutherford())
             kwargs.setdefault('_tracking', True)
+            use_prebuilt_kernels = kwargs.pop('use_prebuilt_kernels', True)
         super().__init__(**kwargs)
         if '_xobject' not in kwargs:
-            self._EverestCollimator_set_material(xp.Particles())
+            self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
+                                 particles_class=xp.Particles,
+                                 only_if_needed=True)
+            self._context.kernels.EverestCollimator_set_material(el=self)
 
     @property
     def material(self):
@@ -139,8 +150,10 @@ class EverestCollimator(BaseCollimator):
         if not isinstance(material, Material):
             if not isinstance('material', dict) or material['__class__'] != "Material":
                 raise ValueError("Invalid material!")
-        self._material = material
-        self._EverestCollimator_set_material(xp.Particles())
+        if not xt.line._dicts_equal(self.material.to_dict(), material.to_dict()):
+            self._material = material
+            self.compile_kernels(particles_class=xp.Particles, only_if_needed=True)
+            self._context.kernels.EverestCollimator_set_material(el=self)
 
     def get_backtrack_element(self, _context=None, _buffer=None, _offset=None):
         return InvalidXcoll(length=-self.length, _context=_context,
@@ -179,10 +192,10 @@ class EverestCrystal(BaseCollimator):
         _pkg_root.joinpath('beam_elements','collimators_src','everest_crystal.h')
     ]
 
-    _per_particle_kernels = {
-        '_EverestCrystal_set_material': xo.Kernel(
+    _kernels = {
+        'EverestCrystal_set_material': xo.Kernel(
                 c_name='EverestCrystal_set_material',
-                args=[]
+                args=[xo.Arg(xo.ThisClass, name='el')]
             )
         }
 
@@ -213,13 +226,18 @@ class EverestCrystal(BaseCollimator):
             kwargs['_orient'] = _lattice_setter(kwargs.pop('lattice', 'strip'))
             kwargs.setdefault('rutherford_rng', xt.RandomRutherford())
             kwargs.setdefault('_tracking', True)
+            use_prebuilt_kernels = kwargs.pop('use_prebuilt_kernels', True)
         super().__init__(**kwargs)
         if '_xobject' not in kwargs:
             if bending_radius:
                 self._bending_angle = np.arcsin(self.active_length/bending_radius)
             if bending_angle:
                 self._bending_radius = self.active_length / np.sin(bending_angle)
-            self._EverestCrystal_set_material(xp.Particles())
+            self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
+                                 particles_class=xp.Particles,
+                                 only_if_needed=True)
+            self._context.kernels.EverestCrystal_set_material(el=self)
+
 
     @property
     def critical_angle(self):
@@ -265,8 +283,10 @@ class EverestCrystal(BaseCollimator):
         if not isinstance(material, CrystalMaterial):
             if not isinstance(material, dict) or material['__class__'] != "CrystalMaterial":
                 raise ValueError("Invalid material!")
-        self._material = material
-        self._EverestCrystal_set_material(xp.Particles())
+        if not xt.line._dicts_equal(self.material.to_dict(), material.to_dict()):
+            self._material = material
+            self.compile_kernels(particles_class=xp.Particles, only_if_needed=True)
+            self._context.kernels.EverestCrystal_set_material(el=self)
 
 
     def get_backtrack_element(self, _context=None, _buffer=None, _offset=None):
@@ -282,4 +302,18 @@ def _lattice_setter(lattice):
     else:
         raise ValueError(f"Illegal value {lattice} for 'lattice'! "
                         + "Only use 'strip' (110) or 'quasi-mosaic' (111).")
+
+
+# TODO: We want this in the HybridClass to get Kernels attached automatically,
+#       like the PerParticlePyMethod in BeamElement
+# def _exec_kernel(el, kernel_name, **kwargs):
+# #     context = el._context
+# #     desired_classes  = tuple(a.atype for a in el._kernels[kernel_name].args)
+# #     if (kernel_name, desired_classes) not in context.kernels:
+# #         el.compile_kernels(particles_class=xp.Particles)
+# #     kern = context.kernels[(kernel_name, desired_classes)]
+# #     return kern(el=el._xobject, **kwargs)
+#     el.compile_kernels(particles_class=xp.Particles, only_if_needed=True)
+#     return getattr(el._context.kernels, kernel_name)(el=el, **kwargs)
+
 

--- a/xcoll/beam_elements/everest.py
+++ b/xcoll/beam_elements/everest.py
@@ -14,7 +14,6 @@ from ..scattering_routines.everest import GeneralMaterial, Material, CrystalMate
 from ..general import _pkg_root
 
 
-
 # TODO:
 #      We want these elements to behave as if 'iscollective = True' when doing twiss etc (because they would ruin the CO),
 #      but as if 'iscollective = False' for normal tracking as it is natively in C...
@@ -68,8 +67,12 @@ class EverestBlock(BaseBlock):
             use_prebuilt_kernels = kwargs.pop('use_prebuilt_kernels', True)
         super().__init__(**kwargs)
         if '_xobject' not in kwargs:
-            self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
+            try:   # TODO: small workaround until PR
+                self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
                                  particles_class=xp.Particles,
+                                 only_if_needed=True)
+            except TypeError:
+                self.compile_kernels(particles_class=xp.Particles,
                                  only_if_needed=True)
             self._context.kernels.EverestBlock_set_material(el=self)
 
@@ -136,8 +139,12 @@ class EverestCollimator(BaseCollimator):
             use_prebuilt_kernels = kwargs.pop('use_prebuilt_kernels', True)
         super().__init__(**kwargs)
         if '_xobject' not in kwargs:
-            self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
+            try:   # TODO: small workaround until PR
+                self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
                                  particles_class=xp.Particles,
+                                 only_if_needed=True)
+            except TypeError:
+                self.compile_kernels(particles_class=xp.Particles,
                                  only_if_needed=True)
             self._context.kernels.EverestCollimator_set_material(el=self)
 
@@ -233,8 +240,12 @@ class EverestCrystal(BaseCollimator):
                 self._bending_angle = np.arcsin(self.active_length/bending_radius)
             if bending_angle:
                 self._bending_radius = self.active_length / np.sin(bending_angle)
-            self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
+            try:   # TODO: small workaround until PR
+                self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
                                  particles_class=xp.Particles,
+                                 only_if_needed=True)
+            except TypeError:
+                self.compile_kernels(particles_class=xp.Particles,
                                  only_if_needed=True)
             self._context.kernels.EverestCrystal_set_material(el=self)
 

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -12,5 +12,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ===================
 # Do not change
 # ===================
-__version__ = '0.3.1'
+__version__ = '0.3.2'
 # ===================

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 _pkg_root = Path(__file__).parent.absolute()
 
-citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools for Collimation Simulations in Xsuite."
+citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools for Collimation Simulations in Xsuite, Proceedings of HB2023, Geneva, Switzerland."
 
 # ===================
 # Do not change

--- a/xcoll/headers/checks.h
+++ b/xcoll/headers/checks.h
@@ -10,18 +10,18 @@
 int8_t xcoll_check_particle_init(RandomRutherfordData rng, LocalParticle* part) {
     int8_t is_tracking = assert_tracking(part, XC_ERR_INVALID_TRACK);
     if (!is_tracking){
-        printf("Collimator tracking code is called, but we are not supposed to be tracking!");
-        fflush(stdout);
+        printf("Collimator tracking code is called, but we are not supposed to be tracking!"); //only_for_context cpu_serial
+        fflush(stdout);                                                                        //only_for_context cpu_serial
     }
     int8_t rng_is_set  = assert_rng_set(part, RNG_ERR_SEEDS_NOT_SET);
     if (!rng_is_set){
-        printf("Random generator seeds in particles object are not set!");
-        fflush(stdout);
+        printf("Random generator seeds in particles object are not set!"); //only_for_context cpu_serial
+        fflush(stdout);                                                    //only_for_context cpu_serial
     }
     int8_t ruth_is_set = assert_rutherford_set(rng, part, RNG_ERR_RUTH_NOT_SET);
     if (!ruth_is_set){
-        printf("Rutherford random generator not initialised!");
-        fflush(stdout);
+        printf("Rutherford random generator not initialised!"); //only_for_context cpu_serial
+        fflush(stdout);                                         //only_for_context cpu_serial
     }
     return is_tracking*rng_is_set*ruth_is_set;
 }

--- a/xcoll/manager.py
+++ b/xcoll/manager.py
@@ -913,7 +913,7 @@ class CollimatorManager:
 
         if file is not None:
             with open(Path(file), 'w') as fid:
-                json.dump(self._lossmap, fid, indent=True)
+                json.dump(self._lossmap, fid, cls=xo.JEncoder, indent=True)
     
         return self._lossmap
 

--- a/xcoll/scattering_routines/everest/everest.h
+++ b/xcoll/scattering_routines/everest/everest.h
@@ -43,6 +43,7 @@ typedef struct EverestCollData_ {
     double ai;
     double eum;
     double collnt;
+    int8_t only_mcs;
 } EverestCollData_;
 typedef EverestCollData_ *EverestCollData;
 

--- a/xcoll/scattering_routines/everest/jaw.h
+++ b/xcoll/scattering_routines/everest/jaw.h
@@ -174,7 +174,7 @@ double* jaw(EverestData restrict everest, LocalParticle* part, double p, double 
             int inter = ichoix(everest, part);
             nabs = inter;
             if (inter == 1) {
-                s = (zlm-rlen)+zlm1;
+                s = zlm - rlen + zlm1;
                 m_dpodx = calcionloss(everest, part, rlen);
                 p = p-m_dpodx*s;
                 break;
@@ -208,14 +208,14 @@ double* jaw(EverestData restrict everest, LocalParticle* part, double p, double 
             xp = xp + tx;
             zp = zp + tz;
 
-            // Treat single-diffractive scattering.
+            // Treat single-diffractive scattering.    TODO: this does nothing??
             if(inter == 4) {
                 // added update for s
-                s    = (zlm-rlen)+zlm1;
+                s = zlm - rlen + zlm1;
             }
 
             // Calculate the remaining interaction length and close the iteration loop.
-            rlen = rlen-zlm1;
+            rlen = rlen - zlm1;
         }
     }
 
@@ -223,6 +223,7 @@ double* jaw(EverestData restrict everest, LocalParticle* part, double p, double 
     LocalParticle_set_px(part, xp/rpp_in);
     LocalParticle_set_y(part, z);
     LocalParticle_set_py(part, zp/rpp_in);
+    LocalParticle_add_to_s(part, s);  // TODO: is this correct with tilt etc?
 
     result[0] = p;
     result[1] = nabs;

--- a/xcoll/scattering_routines/everest/jaw.h
+++ b/xcoll/scattering_routines/everest/jaw.h
@@ -90,7 +90,7 @@ int ichoix(EverestData restrict everest, LocalParticle* part) {
 
 
 /*gpufun*/
-double* jaw(EverestData restrict everest, LocalParticle* part, double p, double zlm, int only_mcs, int edge_check) {
+double* jaw(EverestData restrict everest, LocalParticle* part, double p, double zlm, int edge_check) {
 
     double* result = (double*)malloc(3 * sizeof(double));
 
@@ -108,7 +108,7 @@ double* jaw(EverestData restrict everest, LocalParticle* part, double p, double 
     double z  = LocalParticle_get_y(part);
     double zp = LocalParticle_get_py(part)*rpp_in;
 
-    if (only_mcs) {
+    if (everest->coll->only_mcs) {
         double* res = mcs(everest, part, zlm, p, x, xp, z, zp, edge_check);
         s = res[0];
         x = res[1];

--- a/xcoll/scattering_routines/everest/materials.py
+++ b/xcoll/scattering_routines/everest/materials.py
@@ -1,6 +1,6 @@
 # copyright ############################### #
-# This file is part of the Xcoll Package.  #
-# Copyright (c) CERN, 2023.                 #
+# This file is part of the Xcoll Package.   #
+# Copyright (c) CERN, 2024.                 #
 # ######################################### #
 
 import xobjects as xo
@@ -31,7 +31,8 @@ class GeneralMaterial(xo.HybridClass):
                 # Index 0:Total, 1:absorption, 2:nuclear elastic, 3:pp or pn elastic
                 #       4:Single Diffractive pp or pn, 5:Coulomb for t above mcs
         'hcut':                     xo.Float64,
-        'name':                     xo.String
+        'name':                     xo.String,
+        '_only_mcs':                xo.Int8
     }
 
     def __init__(self, **kwargs):
@@ -40,6 +41,15 @@ class GeneralMaterial(xo.HybridClass):
             kwargs.setdefault('cross_section', [0., 0., 0., 0., 0., 0.])
             kwargs.setdefault('name', "NO NAME")
             kwargs['name'] = kwargs['name'].ljust(55)  # Pre-allocate 64 byte using whitespace
+            # TODO: this should be better
+            if kwargs.get('Z', None) is None or kwargs.get('A', None) is None \
+            or kwargs.get('density', None) is None \
+            or kwargs.get('excitation_energy', None) is None \
+            or kwargs.get('nuclear_radius', None) is None \
+            or kwargs.get('nuclear_elastic_slope', None) is None:
+                kwargs['_only_mcs'] = True
+            else:
+                kwargs['_only_mcs'] = False
         super().__init__(**kwargs)
         self.name = self.name.strip()
 

--- a/xcoll/scattering_routines/everest/multiple_coulomb_scattering.h
+++ b/xcoll/scattering_routines/everest/multiple_coulomb_scattering.h
@@ -145,10 +145,10 @@ double* mcs(EverestData restrict everest, LocalParticle* part, double zlm1, doub
             xp = res[1];
             free(res);
             if (x <= 0) {
-                s = (rlen0-rlen)+ s;
+                s = rlen0 - rlen + s;
                 break; // go to 20
             }
-            if ((s + dh) >= rlen) {
+            if (s + dh >= rlen) {
                 s = rlen0;
                 break; // go to 20
             }
@@ -157,11 +157,11 @@ double* mcs(EverestData restrict everest, LocalParticle* part, double zlm1, doub
         }
 
     } else {
-        s = rlen0;
-        double* res = scamcs(part, x, xp, s);
+        double* res = scamcs(part, x, xp, rlen0);
         x  = res[0];
         xp = res[1];
         free(res);
+        s = rlen0;
     }
 
     double* res = scamcs(part, z, zp, s);

--- a/xcoll/scattering_routines/everest/scatter.h
+++ b/xcoll/scattering_routines/everest/scatter.h
@@ -89,7 +89,7 @@ void scatter(EverestData restrict everest, LocalParticle* part, double length){
         if (zlm > 0.) {
             is_hit = 1;
 
-            double* jaw_result = jaw(everest, part, energy, zlm, 0, 1);
+            double* jaw_result = jaw(everest, part, energy, zlm, 1);
 
             energy = jaw_result[0];
             if (jaw_result[1] == 1){
@@ -99,7 +99,7 @@ void scatter(EverestData restrict everest, LocalParticle* part, double length){
             free(jaw_result);
 
             if (is_abs != 1) {
-            // Do the rest drift, if particle left collimator early
+               // Do the rest drift, if particle left collimator early
                 Drift_single_particle_4d(part, zlm-s_out);
             }
         }


### PR DESCRIPTION
- Another small bugfix that was overwritten by the merge: dumping the lossmap to JSON needs xo.JEncoder
- Bugfix to make Absorber work on GPU (fflush only on CPU_serial)
- Define element_classes for prebuilt kernels
- Moved only_mcs to GeneralMaterial
- Test to auto-regenerate kernels
- Important bugfix: s-coordinate was not updating correctly in Everest
- Changed the material setter in the Everest elements from a per-particle kernel to a regular kernel
- Updated kernels to work even if PR with prebuilt kernels is not yet merged
- Updated version number to v0.3.2.
