### PR TITLE
Changes required for removing ParticlesBase

### DIFF
--- a/xcoll/beam_elements/everest.py
+++ b/xcoll/beam_elements/everest.py
@@ -69,11 +69,9 @@ class EverestBlock(BaseBlock):
         if '_xobject' not in kwargs:
             try:   # TODO: small workaround until PR
                 self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
-                                 particles_class=xp.Particles,
-                                 only_if_needed=True)
+                                     only_if_needed=True)
             except TypeError:
-                self.compile_kernels(particles_class=xp.Particles,
-                                 only_if_needed=True)
+                self.compile_kernels(only_if_needed=True)
             self._context.kernels.EverestBlock_set_material(el=self)
 
 
@@ -88,7 +86,7 @@ class EverestBlock(BaseBlock):
                 raise ValueError("Invalid material!")
         if not xt.line._dicts_equal(self.material.to_dict(), material.to_dict()):
             self._material = material
-            self.compile_kernels(particles_class=xp.Particles, only_if_needed=True)
+            self.compile_kernels(only_if_needed=True)
             self._context.kernels.EverestBlock_set_material(el=self)
 
     def get_backtrack_element(self, _context=None, _buffer=None, _offset=None):
@@ -141,11 +139,9 @@ class EverestCollimator(BaseCollimator):
         if '_xobject' not in kwargs:
             try:   # TODO: small workaround until PR
                 self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
-                                 particles_class=xp.Particles,
-                                 only_if_needed=True)
+                                     only_if_needed=True)
             except TypeError:
-                self.compile_kernels(particles_class=xp.Particles,
-                                 only_if_needed=True)
+                self.compile_kernels(only_if_needed=True)
             self._context.kernels.EverestCollimator_set_material(el=self)
 
     @property
@@ -159,7 +155,7 @@ class EverestCollimator(BaseCollimator):
                 raise ValueError("Invalid material!")
         if not xt.line._dicts_equal(self.material.to_dict(), material.to_dict()):
             self._material = material
-            self.compile_kernels(particles_class=xp.Particles, only_if_needed=True)
+            self.compile_kernels(only_if_needed=True)
             self._context.kernels.EverestCollimator_set_material(el=self)
 
     def get_backtrack_element(self, _context=None, _buffer=None, _offset=None):
@@ -242,11 +238,9 @@ class EverestCrystal(BaseCollimator):
                 self._bending_radius = self.active_length / np.sin(bending_angle)
             try:   # TODO: small workaround until PR
                 self.compile_kernels(use_prebuilt_kernels=use_prebuilt_kernels,
-                                 particles_class=xp.Particles,
-                                 only_if_needed=True)
+                                     only_if_needed=True)
             except TypeError:
-                self.compile_kernels(particles_class=xp.Particles,
-                                 only_if_needed=True)
+                self.compile_kernels(only_if_needed=True)
             self._context.kernels.EverestCrystal_set_material(el=self)
 
 
@@ -296,7 +290,7 @@ class EverestCrystal(BaseCollimator):
                 raise ValueError("Invalid material!")
         if not xt.line._dicts_equal(self.material.to_dict(), material.to_dict()):
             self._material = material
-            self.compile_kernels(particles_class=xp.Particles, only_if_needed=True)
+            self.compile_kernels(only_if_needed=True)
             self._context.kernels.EverestCrystal_set_material(el=self)
 
 
@@ -313,18 +307,3 @@ def _lattice_setter(lattice):
     else:
         raise ValueError(f"Illegal value {lattice} for 'lattice'! "
                         + "Only use 'strip' (110) or 'quasi-mosaic' (111).")
-
-
-# TODO: We want this in the HybridClass to get Kernels attached automatically,
-#       like the PerParticlePyMethod in BeamElement
-# def _exec_kernel(el, kernel_name, **kwargs):
-# #     context = el._context
-# #     desired_classes  = tuple(a.atype for a in el._kernels[kernel_name].args)
-# #     if (kernel_name, desired_classes) not in context.kernels:
-# #         el.compile_kernels(particles_class=xp.Particles)
-# #     kern = context.kernels[(kernel_name, desired_classes)]
-# #     return kern(el=el._xobject, **kwargs)
-#     el.compile_kernels(particles_class=xp.Particles, only_if_needed=True)
-#     return getattr(el._context.kernels, kernel_name)(el=el, **kwargs)
-
-

--- a/xcoll/scattering_routines/everest/materials.py
+++ b/xcoll/scattering_routines/everest/materials.py
@@ -88,236 +88,256 @@ class CrystalMaterial(GeneralMaterial):
         return cls(**thisdict)
 
 
-
-
+_materials_context = xo.ContextCpu()
 
 # BE
 Beryllium = Material(
-        name = 'Beryllium',
-        Z = 4.00,
-        A = 9.01,
-        density = 1.848,
-        excitation_energy = 63.7e-9,
-        radiation_length = 0.353,
-        nuclear_radius = 0.22,
-        nuclear_elastic_slope = 74.7,
-        cross_section = [0.271, 0.192, 0, 0, 0, 0.0035e-2]
+    name='Beryllium',
+    Z=4.00,
+    A=9.01,
+    density=1.848,
+    excitation_energy=63.7e-9,
+    radiation_length=0.353,
+    nuclear_radius=0.22,
+    nuclear_elastic_slope=74.7,
+    cross_section=[0.271, 0.192, 0, 0, 0, 0.0035e-2],
+    _context=_materials_context,
 )
 
 # AL
 Aluminium = Material(
-        name = 'Aluminium',
-        Z = 13.00,
-        A = 26.98,
-        density = 2.70,
-        excitation_energy = 166.0e-9,
-        radiation_length = 0.089,
-        nuclear_radius = 0.302,
-        nuclear_elastic_slope = 120.3,
-        cross_section = [0.643, 0.418, 0, 0, 0, 0.0340e-2]
+    name='Aluminium',
+    Z=13.00,
+    A=26.98,
+    density=2.70,
+    excitation_energy=166.0e-9,
+    radiation_length=0.089,
+    nuclear_radius=0.302,
+    nuclear_elastic_slope=120.3,
+    cross_section=[0.643, 0.418, 0, 0, 0, 0.0340e-2],
+    _context=_materials_context,
 )
 
 # CU
 Copper = Material(
-        name = 'Copper',
-        Z = 29.00,
-        A = 63.55,
-        density = 8.96,
-        excitation_energy = 322.0e-9,
-        hcut = 0.01,
-        nuclear_radius = 0.366,
-        radiation_length = 0.0143,
-        nuclear_elastic_slope = 217.8,
-        cross_section = [1.253, 0.769, 0, 0, 0, 0.1530e-2]
+    name='Copper',
+    Z=29.00,
+    A=63.55,
+    density=8.96,
+    excitation_energy=322.0e-9,
+    hcut=0.01,
+    nuclear_radius=0.366,
+    radiation_length=0.0143,
+    nuclear_elastic_slope=217.8,
+    cross_section=[1.253, 0.769, 0, 0, 0, 0.1530e-2],
+    _context=_materials_context,
 )
 
 # W
 Tungsten = Material(
-        name = 'Tungsten',
-        Z = 74.00,
-        A = 183.85,
-        density = 19.30,
-        excitation_energy = 727.0e-9,
-        hcut = 0.01,
-        nuclear_radius = 0.520, 
-        radiation_length = 0.0035,
-        nuclear_elastic_slope = 440.3,
-        cross_section = [2.765, 1.591, 0, 0, 0, 0.7680e-2]
+    name='Tungsten',
+    Z=74.00,
+    A=183.85,
+    density=19.30,
+    excitation_energy=727.0e-9,
+    hcut=0.01,
+    nuclear_radius=0.520,
+    radiation_length=0.0035,
+    nuclear_elastic_slope=440.3,
+    cross_section=[2.765, 1.591, 0, 0, 0, 0.7680e-2],
+    _context=_materials_context,
 )
-TungstenCrystal = CrystalMaterial.from_material( Tungsten,
-        crystal_radiation_length = 0.0035,
-        crystal_nuclear_length = 0.096,
-        crystal_plane_distance = 0.56e-7,
-        crystal_potential = 21.0,
-        nuclear_collision_length = 0
+TungstenCrystal = CrystalMaterial.from_material(
+    Tungsten,
+    crystal_radiation_length=0.0035,
+    crystal_nuclear_length=0.096,
+    crystal_plane_distance=0.56e-7,
+    crystal_potential=21.0,
+    nuclear_collision_length=0,
+    _context=_materials_context,
 )
 
 # PB
 Lead = Material(
-        name = 'Lead',
-        Z = 82.00,
-        A = 207.19,
-        density = 11.35,
-        excitation_energy = 823.0e-9,
-        hcut = 0.01,
-        nuclear_radius = 0.542,
-        radiation_length = 0.0056,
-        nuclear_elastic_slope = 455.3,
-        cross_section = [3.016, 1.724, 0, 0, 0, 0.9070e-2]
+    name='Lead',
+    Z=82.00,
+    A=207.19,
+    density=11.35,
+    excitation_energy=823.0e-9,
+    hcut=0.01,
+    nuclear_radius=0.542,
+    radiation_length=0.0056,
+    nuclear_elastic_slope=455.3,
+    cross_section=[3.016, 1.724, 0, 0, 0, 0.9070e-2],
+    _context=_materials_context,
 )
 
 # C
 Carbon = Material(
-        name = 'Carbon',
-        Z = 6.00,
-        A = 12.01,
-        density = 1.67,
-        excitation_energy = 78.0e-9,
-        radiation_length = 0.2557,
-        nuclear_radius = 0.25,
-        nuclear_elastic_slope = 70.0,
-        cross_section = [0.337, 0.232, 0, 0, 0, 0.0076e-2]
+    name='Carbon',
+    Z=6.00,
+    A=12.01,
+    density=1.67,
+    excitation_energy=78.0e-9,
+    radiation_length=0.2557,
+    nuclear_radius=0.25,
+    nuclear_elastic_slope=70.0,
+    cross_section=[0.337, 0.232, 0, 0, 0, 0.0076e-2],
+    _context=_materials_context,
 )
-CarbonCrystal = CrystalMaterial.from_material( Carbon,
-        crystal_radiation_length = 0.188,
-        crystal_nuclear_length = 0.400,
-        crystal_plane_distance = 0.63e-7,
-        crystal_potential = 21.0,
-        nuclear_collision_length = 0
+CarbonCrystal = CrystalMaterial.from_material(
+    Carbon,
+    crystal_radiation_length=0.188,
+    crystal_nuclear_length=0.400,
+    crystal_plane_distance=0.63e-7,
+    crystal_potential=21.0,
+    nuclear_collision_length=0,
+    _context=_materials_context,
 )
 
 # C2
 Carbon2 = Material(
-        name = 'Carbon2',
-        Z = 6.00,
-        A = 12.01,
-        density = 4.52,
-        excitation_energy = 78.0e-9,
-        radiation_length = 0.094,
-        nuclear_radius = 0.25,
-        nuclear_elastic_slope = 70.0,
-        cross_section = [0.337, 0.232, 0, 0, 0, 0.0076e-2]
+    name='Carbon2',
+    Z=6.00,
+    A=12.01,
+    density=4.52,
+    excitation_energy=78.0e-9,
+    radiation_length=0.094,
+    nuclear_radius=0.25,
+    nuclear_elastic_slope=70.0,
+    cross_section=[0.337, 0.232, 0, 0, 0, 0.0076e-2],
+    _context=_materials_context,
 )
 
 # Si
 Silicon = Material(
-        name = 'Silicon',
-        Z = 14.00,
-        A = 28.08,
-        density = 2.33,
-        excitation_energy = 173.0e-9,
-        radiation_length = 1,
-        nuclear_radius = 0.441,
-        nuclear_elastic_slope = 120.14,
-        cross_section = [0.664, 0.430, 0, 0, 0, 0.0390e-2]
+    name='Silicon',
+    Z=14.00,
+    A=28.08,
+    density=2.33,
+    excitation_energy=173.0e-9,
+    radiation_length=1,
+    nuclear_radius=0.441,
+    nuclear_elastic_slope=120.14,
+    cross_section=[0.664, 0.430, 0, 0, 0, 0.0390e-2],
+    _context=_materials_context,
 )
-SiliconCrystal = CrystalMaterial.from_material( Silicon,
-        crystal_radiation_length = 0.0937,
-        crystal_nuclear_length = 0.4652,
-        crystal_plane_distance = 0.96e-7,
-        crystal_potential = 21.34,
-        nuclear_collision_length = 0.3016
+SiliconCrystal = CrystalMaterial.from_material(
+    Silicon,
+    crystal_radiation_length=0.0937,
+    crystal_nuclear_length=0.4652,
+    crystal_plane_distance=0.96e-7,
+    crystal_potential=21.34,
+    nuclear_collision_length=0.3016,
+    _context=_materials_context,
 )
 
 # Ge
 Germanium = Material(
-        name = 'Germanium',
-        Z = 32.00,
-        A = 72.63,
-        density = 5.323,
-        excitation_energy = 350.0e-9,
-        radiation_length = 1,
-        nuclear_radius = 0.605,
-        nuclear_elastic_slope = 226.35,
-        cross_section = [1.388, 0.844, 0, 0, 0, 0.1860e-2]
+    name='Germanium',
+    Z=32.00,
+    A=72.63,
+    density=5.323,
+    excitation_energy=350.0e-9,
+    radiation_length=1,
+    nuclear_radius=0.605,
+    nuclear_elastic_slope=226.35,
+    cross_section=[1.388, 0.844, 0, 0, 0, 0.1860e-2],
+    _context=_materials_context,
 )
-GermaniumCrystal = CrystalMaterial.from_material( Germanium,
-        crystal_radiation_length = 0.02302,
-        crystal_nuclear_length = 0.2686,
-        crystal_plane_distance = 1.0e-7,
-        crystal_potential = 40.0,
-        nuclear_collision_length = 0.1632
+GermaniumCrystal = CrystalMaterial.from_material(
+    Germanium,
+    crystal_radiation_length=0.02302,
+    crystal_nuclear_length=0.2686,
+    crystal_plane_distance=1.0e-7,
+    crystal_potential=40.0,
+    nuclear_collision_length=0.1632,
+    _context=_materials_context,
 )
 
 # MoGR
 MolybdenumGraphite = Material(
-        name = 'MolybdenumGraphite',
-        Z = 6.65,
-        A = 13.53,
-        density = 2.500,
-        excitation_energy = 87.1e-9,
-        radiation_length = 0.1193,
-        nuclear_radius = 0.25,
-        nuclear_elastic_slope = 76.7,
-        cross_section = [0.362, 0.247, 0, 0, 0, 0.0094e-2]
+    name='MolybdenumGraphite',
+    Z=6.65,
+    A=13.53,
+    density=2.500,
+    excitation_energy=87.1e-9,
+    radiation_length=0.1193,
+    nuclear_radius=0.25,
+    nuclear_elastic_slope=76.7,
+    cross_section=[0.362, 0.247, 0, 0, 0, 0.0094e-2],
+    _context=_materials_context,
 )
 
 # CuCD
 CopperDiamond = Material(
-        name = 'CopperDiamond',
-        Z = 11.90,
-        A = 25.24,
-        density = 5.40,
-        excitation_energy = 152.9e-9,
-        radiation_length = 0.0316,
-        nuclear_radius = 0.308,
-        nuclear_elastic_slope = 115.0,
-        cross_section = [0.572, 0.370, 0, 0, 0, 0.0279e-2]
+    name='CopperDiamond',
+    Z=11.90,
+    A=25.24,
+    density=5.40,
+    excitation_energy=152.9e-9,
+    radiation_length=0.0316,
+    nuclear_radius=0.308,
+    nuclear_elastic_slope=115.0,
+    cross_section=[0.572, 0.370, 0, 0, 0, 0.0279e-2],
+    _context=_materials_context,
 )
 
 # Mo
 Molybdenum = Material(
-        name = 'Molybdenum',
-        Z = 42.00,
-        A = 95.96,
-        density = 10.22,
-        excitation_energy = 424.0e-9,
-        radiation_length = 0.0096,
-        nuclear_radius = 0.481,
-        nuclear_elastic_slope = 273.9,
-        cross_section = [1.713, 1.023, 0, 0, 0, 0.2650e-2]
+    name='Molybdenum',
+    Z=42.00,
+    A=95.96,
+    density=10.22,
+    excitation_energy=424.0e-9,
+    radiation_length=0.0096,
+    nuclear_radius=0.481,
+    nuclear_elastic_slope=273.9,
+    cross_section=[1.713, 1.023, 0, 0, 0, 0.2650e-2],
+    _context=_materials_context,
 )
 
 # Glid
 Glidcop = Material(
-        name = 'Glidcop',
-        Z = 28.80,
-        A = 63.15,
-        density = 8.93,
-        excitation_energy = 320.8e-9,
-        radiation_length = 0.0144,
-        nuclear_radius = 0.418,
-        nuclear_elastic_slope = 208.7,
-        cross_section = [1.246, 0.765, 0, 0, 0, 0.1390e-2]
+    name='Glidcop',
+    Z=28.80,
+    A=63.15,
+    density=8.93,
+    excitation_energy=320.8e-9,
+    radiation_length=0.0144,
+    nuclear_radius=0.418,
+    nuclear_elastic_slope=208.7,
+    cross_section=[1.246, 0.765, 0, 0, 0, 0.1390e-2],
+    _context=_materials_context,
 )
 
 # Iner
 Inermet = Material(
-        name = 'Inermet',
-        Z = 67.70,
-        A = 166.70,
-        density = 18.00,
-        excitation_energy = 682.2e-9,
-        radiation_length = 0.00385,
-        nuclear_radius = 0.578,
-        nuclear_elastic_slope = 392.1,
-        cross_section = [2.548, 1.473, 0, 0, 0, 0.5740e-2]
+    name='Inermet',
+    Z=67.70,
+    A=166.70,
+    density=18.00,
+    excitation_energy=682.2e-9,
+    radiation_length=0.00385,
+    nuclear_radius=0.578,
+    nuclear_elastic_slope=392.1,
+    cross_section=[2.548, 1.473, 0, 0, 0, 0.5740e-2],
+    _context=_materials_context,
 )
 
-
 SixTrack_to_xcoll = {
-    "be":   [Beryllium],
-    "al":   [Aluminium],
-    "cu":   [Copper],
-    "w":    [Tungsten, TungstenCrystal],
-    "pb":   [Lead],
-    "c":    [Carbon, CarbonCrystal],
-    "c2":   [Carbon2],
-    "si":   [Silicon, SiliconCrystal],
-    "ge":   [Germanium, GermaniumCrystal],
+    "be": [Beryllium],
+    "al": [Aluminium],
+    "cu": [Copper],
+    "w": [Tungsten, TungstenCrystal],
+    "pb": [Lead],
+    "c": [Carbon, CarbonCrystal],
+    "c2": [Carbon2],
+    "si": [Silicon, SiliconCrystal],
+    "ge": [Germanium, GermaniumCrystal],
     "mogr": [MolybdenumGraphite],
     "cucd": [CopperDiamond],
-    "mo":   [Molybdenum],
+    "mo": [Molybdenum],
     "glid": [Glidcop],
     "iner": [Inermet]
 }


### PR DESCRIPTION
## Description

1. Remove the `particles_class` argument from some methods that no longer require it, following the proposed changes to xtrack and xpart (https://github.com/xsuite/xtrack/pull/449).
2. Put materials on a context different from context_default. This is needed, as otherwise whenever xcoll is imported, the materials are allocated on the default context. This is not in itself wrong, but causes a problem for the test run of xtrack, where emptiness of the default context is checked (as a means of detecting memory leaks -- this was a problem in the past). Rather than disabling the check, we can allocate the materials on a different context, as a means of specifying that these are valid allocations. Maybe a better solution can be found, but for now this seems the best.

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [x] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
