### PR TITLE
Added casting to unsigned int to ensure positive value for malloc

### DIFF
--- a/xcoll/scattering_routines/geometry/objects.h
+++ b/xcoll/scattering_routines/geometry/objects.h
@@ -40,7 +40,7 @@ void destroy_jaw(Segment* segments){
 
 /*gpufun*/
 Segment* create_polygon(double* s_poly, double* x_poly, int8_t num_polys){
-    Segment* segments= (Segment*) malloc(num_polys*sizeof(Segment));
+    Segment* segments= (Segment*) malloc((unsigned int) num_polys*sizeof(Segment));
     for (int8_t i=0; i<num_polys-1; i++){
         segments[i] = (Segment) create_line_segment(s_poly[i], x_poly[i], s_poly[i+1], x_poly[i+1]);
     }


### PR DESCRIPTION
## Description
Added casting to unsigned int to ensure positive value for malloc.
Geometry test passes. The warning  from the compiling is gone.

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
