### PR TITLE
Offset removed, and added collimators list option to get touches

### DIFF
--- a/xcoll/scattering_routines/fluka/engine.py
+++ b/xcoll/scattering_routines/fluka/engine.py
@@ -157,9 +157,31 @@ class FlukaEngine(xo.HybridClass):
         if this.is_running():
             print("Server already running.", flush=True)
             return
+
+        timeout = 180 # Checking for 3 minutes if _fluka and _flukaserver exist.
+        start_time = time.time()
+
+        while time.time() - start_time < timeout:
+            if this._fluka.exists() and this._flukaserver.exists():
+                break
+            time.sleep(1)
+
         if not this._fluka.exists():
-            raise ValueError(f"Could not find fluka executable {this._fluka}!")
+            print(f"Could not find fluka executable {this._fluka}!")
+            print("Trying modifying the eos path project-f->project/f")
+            fluka_folder = os.path.dirname(this._fluka)
+            if not os.path.exists(fluka_folder):
+                print(f"Could not find the folder for fluka executable {fluka_folder}!")
+            this._fluka = this._fluka.replace("project-f", "project/f")
+            if not this_fluka.exists():
+                raise ValueError(f"Could not find fluka executable {this._fluka}!")
         if not this._flukaserver.exists():
+            flukaserver_folder = os.path.dirname(this._flukaserver)
+            if not os.path.exists(flukaserver_folder):
+                print(f"Could not find the folder for fluka executable {flukaserver_folder}!")
+            this._flukaserver = this._flukaserver.replace("project-f", "project/f")
+            if not this_fluka.exists():
+                raise ValueError(f"Could not find fluka executable {this._flukaserver}!")
             raise ValueError(f"Could not find flukaserver executable {this._flukaserver}!")
         this.test_gfortran()
         this._starting_server = True

--- a/xcoll/scattering_routines/fluka/engine.py
+++ b/xcoll/scattering_routines/fluka/engine.py
@@ -173,16 +173,17 @@ class FlukaEngine(xo.HybridClass):
             if not os.path.exists(fluka_folder):
                 print(f"Could not find the folder for fluka executable {fluka_folder}!")
             this._fluka = this._fluka.replace("project-f", "project/f")
-            if not this_fluka.exists():
+            if not this._fluka.exists():
                 raise ValueError(f"Could not find fluka executable {this._fluka}!")
         if not this._flukaserver.exists():
+            print(f"Could not find fluka executable {this._flukaserver}!")
+            print("Trying modifying the eos path project-f->project/f")
             flukaserver_folder = os.path.dirname(this._flukaserver)
             if not os.path.exists(flukaserver_folder):
                 print(f"Could not find the folder for fluka executable {flukaserver_folder}!")
             this._flukaserver = this._flukaserver.replace("project-f", "project/f")
-            if not this_fluka.exists():
+            if not this._flukaserver.exists():
                 raise ValueError(f"Could not find fluka executable {this._flukaserver}!")
-            raise ValueError(f"Could not find flukaserver executable {this._flukaserver}!")
         this.test_gfortran()
         this._starting_server = True
 

--- a/xcoll/scattering_routines/fluka/engine.py
+++ b/xcoll/scattering_routines/fluka/engine.py
@@ -225,8 +225,20 @@ class FlukaEngine(xo.HybridClass):
                 fid.write(f'{len(this._collimator_dict.keys())}\n')
                 for _, el in this._collimator_dict.items():
                     fid.write(f'{el["fluka_id"]} ')
-        elif touches is not None and touches is not False:
-            raise NotImplementedError("Only True or False are allowed for `touches` for now.")
+
+        # Check if touches is a list of collimator names
+        elif touches is not None:
+            if isinstance(touches, list):
+                relcol = Path('relcol.dat').resolve()
+                with relcol.open('w') as fid:
+                    fid.write(f'{len(touches)}\n')
+                    for touch in touches:
+                        if touch not in this._collimator_dict.keys():
+                            raise ValueError(f"Collimator {touch} not in collimator dict!")
+                        else:
+                            fid.write(f'{this._collimator_dict[touch]["fluka_id"]} ')
+        # and touches is not False:
+        #     raise NotImplementedError("Only True or False are allowed for `touches` for now.")
         # relcol.dat: first line is the number of collimators, second line is the IDs (no newline at end)
 
         cls.clean_output_files()

--- a/xcoll/scattering_routines/fluka/fluka_input.py
+++ b/xcoll/scattering_routines/fluka/fluka_input.py
@@ -55,7 +55,7 @@ def _coll_dict(elements, names, dump=False):
                 elif ee.gap_R is not None:
                     nsig = ee.gap_R
                 half_gap = (ee._jaw_LU + ee._jaw_LD - ee._jaw_RU - ee._jaw_RD) / 4
-                offset   = (ee._jaw_LU + ee._jaw_LD + ee._jaw_RU + ee._jaw_RD) / 4
+                offset   = 0 # (ee._jaw_LU + ee._jaw_LD + ee._jaw_RU + ee._jaw_RD) / 4
             tilt_1 = ee.tilt_L
             tilt_2 = ee.tilt_R
 

--- a/xcoll/scattering_routines/fluka/fluka_input.py
+++ b/xcoll/scattering_routines/fluka/fluka_input.py
@@ -43,7 +43,7 @@ def _coll_dict(elements, names, dump=False):
                 nsig = ee.gap_R
                 half_gap = -ee.jaw_R   #  TODO: is the sign correct?
             offset = 0
-            tilt_1 = 0
+            tilt_1= 0
             tilt_2 = ee.tilt_R
         else:
             if ee.jaw_L is None and ee.jaw_R is None:
@@ -55,7 +55,7 @@ def _coll_dict(elements, names, dump=False):
                 elif ee.gap_R is not None:
                     nsig = ee.gap_R
                 half_gap = (ee._jaw_LU + ee._jaw_LD - ee._jaw_RU - ee._jaw_RD) / 4
-                offset   = 0 # (ee._jaw_LU + ee._jaw_LD + ee._jaw_RU + ee._jaw_RD) / 4
+                offset   = (ee._jaw_LU + ee._jaw_LD + ee._jaw_RU + ee._jaw_RD) / 4
             tilt_1 = ee.tilt_L
             tilt_2 = ee.tilt_R
 
@@ -69,6 +69,8 @@ def _coll_dict(elements, names, dump=False):
             'sigma_x': 1,
             'sigma_y': 1,
             'offset': offset,
+            'offset_x': 0, # -ee.co[1][0] if ee.co is not None else 0,
+            'offset_y': 0, # -ee.co[1][1] if ee.co is not None else 0,
             'tilt_1': tilt_1,
             'tilt_2': tilt_2,
             'nsig': nsig,

--- a/xcoll/scattering_routines/fluka/paths.py
+++ b/xcoll/scattering_routines/fluka/paths.py
@@ -9,9 +9,12 @@ from pathlib import Path
 _fluka_coupling = Path('/eos/project-f/flukafiles/fluka-coupling').resolve()
 
 # TODO if MR on gitlab accepted, update path
-fluka_builder = Path("/eos/project-c/collimation-team/software/fluka_coupling_tmp_patch_xsuite/tools/preprocess").resolve()
+# fluka_builder = Path("/eos/project-c/collimation-team/software/fluka_coupling_tmp_patch_xsuite/tools/preprocess").resolve()
+#fluka_builder = Path("/afs/cern.ch/user/a/adonadon/conf/dev/fluka_coupling/tools/preprocess").resolve()
 
 fluka = (_fluka_coupling / 'fluka4-4.1' / 'bin' / 'rfluka').resolve()
 flukaserver = (_fluka_coupling / 'fluka_coupling' / 'fluka' / 'flukaserver').resolve()
-linebuilder = (_fluka_coupling / 'linebuilder').resolve()
+#linebuilder = (_fluka_coupling / 'linebuilder').resolve()
+linebuilder = Path("/afs/cern.ch/user/a/adonadon/conf/dev/linebuilder_ads").resolve()
+fluka_builder = (linebuilder / "src").resolve()
 fedb = (_fluka_coupling / 'fedb_coupling').resolve()

--- a/xcoll/scattering_routines/fluka/track.py
+++ b/xcoll/scattering_routines/fluka/track.py
@@ -65,15 +65,15 @@ def track(coll, particles):
 
     _drift(coll, particles, -coll.length_front)
     # FLUKA collimators are centered; need to shift
-    if coll.co is not None:
-        dx = coll.co[1][0]
-        dy = coll.co[1][1]
-        particles.x -= dx
-        particles.y -= dy
+    # if coll.co is not None:
+    #     dx = coll.co[1][0]
+    #     dy = coll.co[1][1]
+    #     particles.x -= dx
+    #     particles.y -= dy
     track_core(coll, particles)
-    if coll.co is not None:
-        particles.x += dx
-        particles.y += dy
+    # if coll.co is not None:
+    #     particles.x += dx
+    #     particles.y += dy
     _drift(coll, particles, -coll.length_back)
 
 


### PR DESCRIPTION
- Observed discrepancies in xsuite/xsuite-fluka/sixtrack-fluka results, mainly in TCTs, seem to be solved when removing the initial offset, which as far as I observed, it was applied twice:

1. In fluka_builder.py, 2. In the xcoll tracking (engine.py)

- Now, it is possible to produce the relcol.dat file getting all the collimators (setting True), or producing a list of the desired collimators.
  To consider if providing an option of predefined collimators groups would be a good idea. For instance:
start(..,touches=TCP,..) to get all the TCPs
