### PR TITLE
K2

### DIFF
--- a/xcoll/beam_elements/elements_src/everest_crystal.h
+++ b/xcoll/beam_elements/elements_src/everest_crystal.h
@@ -271,7 +271,9 @@ void EverestCrystal_track_local_particle(EverestCrystalData el, LocalParticle* p
             }
         }
     //end_per_particle_block
-    EverestCrystalData_set__critical_angle(el, t_c);
+    if (t_c > 1.e-12){
+        EverestCrystalData_set__critical_angle(el, t_c);
+    }
     EverestCrystal_free(cg, active);
     free(coll);
 }

--- a/xcoll/scattering_routines/everest/jaw.h
+++ b/xcoll/scattering_routines/everest/jaw.h
@@ -54,11 +54,11 @@ double jaw(EverestData restrict everest, LocalParticle* part, double p, double l
             // Calculate the remaining interaction length and close the iteration loop.
             rlen = rlen - length_step;
         }
-        // TODO: ionisation loss should also be calculated when only_mcs
-        double m_dpodx = calcionloss(everest, part, rlen);  // DM routine to include tail // TODO: should not be rlen but s after updating
-        double s = LocalParticle_get_s(part) - s0;
-        p = p-m_dpodx*s; // TODO: This is correct: ionisation loss is only calculated and applied at end of while (break)
     }
+    // TODO: ionisation loss should also be calculated when only_mcs
+    double m_dpodx = calcionloss(everest, part, rlen);  // DM routine to include tail // TODO: should not be rlen but s after updating
+    double s = LocalParticle_get_s(part) - s0;
+    p = p-m_dpodx*s; // TODO: This is correct: ionisation loss is only calculated and applied at end of while (break)
 
     return p*1e9;  // Back to eV
 }

--- a/xcoll/scattering_routines/k2/engine.py
+++ b/xcoll/scattering_routines/k2/engine.py
@@ -23,7 +23,6 @@ class K2Engine:
     def __init__(self, **kwargs):
         if(self._initialised):
             for kk, vv in kwargs.items():
-                print("yoehoe")
                 if not hasattr(self, kk):
                     raise ValueError(f"Invalid attribute {kk} for K2Engine!")
                 if kk == 'capacity':

--- a/xcoll/scattering_routines/k2/sixtrack_input.py
+++ b/xcoll/scattering_routines/k2/sixtrack_input.py
@@ -31,24 +31,25 @@ def create_dat_file(line, names, file="k2_colldb.dat"):
             if hasattr(el.angle, '__iter__'):
                 raise ValueError(f"Collimator {name} has jaw-dependent angles. "
                                  f"Not supported.")
-            gap = el.gap
-            if not isinstance(gap, str) and hasattr(gap, '__iter__'):
-                gap = gap[0]  # Only left-sided collimators supported in SixTrack
-            if gap == None:
-                print(f"Warning: ignoring {name} in K2 input file generation as it "
-                      f"has no assigned opening.")
-                continue
             mat = el.material
             length = el.length
             angle = el.angle
+            gap = el.gap
             # SixTrack offset is wrt. closed orbit
             if el.side == 'both':
                 offset = np.round((el.jaw_L + el.jaw_R)/2 - orbit, 9) + 0 # adding 0 to avoid -0 output
+                if not isinstance(gap, str) and hasattr(gap, '__iter__'):
+                    gap = (gap[0] - gap[1])/2 # SixTrack gap is w.r.t. centre, not closed orbit
             elif el.side == 'left':
                 offset = 0.
                 onesided.append(name)
+                if not isinstance(gap, str) and hasattr(gap, '__iter__'):
+                    gap = gap[0]
             else:
                 raise ValueError(f"Right-sided collimator {name} not supported.")
+            if gap == None:
+                print(f"Warning: ignoring {name} in K2 input file generation as it "
+                      f"has no assigned opening.")
             if el.__class__ == _K2Crystal:
                 # Have to do this here and not at the start, to avoid having appended the crystal list
                 # but then continuing (e.g. because the gap is None)


### PR DESCRIPTION
## Description
Fix for gap in sixtrack input file (w.r.t to centre, not closed orbit).
Fix for critical angle by making sure it is properly stored from C to python. 
Fix for only_mcs in the sense that ionization loss is also calculated for only_mcs. 
Removed print statement left from testing.
Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
