### PR TITLE
Amorphous and mcs

### DIFF
--- a/xcoll/scattering_routines/everest/amorphous.h
+++ b/xcoll/scattering_routines/everest/amorphous.h
@@ -193,10 +193,11 @@ double Amorphous(EverestData restrict everest, LocalParticle* part, CrystalGeome
             // We are on the VR side
             pc = amorphous_transport(everest, part, pc, length_VR_trans, 0);
             volume_reflection(everest, part, XC_VOLUME_REFLECTION_TRANS_MCS);
-            pc = amorphous_transport(everest, part, pc, length - length_VR_trans, 0);
+            pc = Amorphous(everest, part, cg,  pc, length - length_VR_trans);
         } else {
             // We are on the AM side
-            pc = amorphous_transport(everest, part, pc, length, XC_MULTIPLE_COULOMB_TRANS_VR);
+            if (sc) InteractionRecordData_log(record, record_index, part, XC_MULTIPLE_COULOMB_TRANS_VR);
+            pc = Amorphous(everest, part, cg, pc, length);
         }
 #endif
 

--- a/xcoll/scattering_routines/everest/multiple_coulomb_scattering.h
+++ b/xcoll/scattering_routines/everest/multiple_coulomb_scattering.h
@@ -160,15 +160,16 @@ void mcs(EverestData restrict everest, LocalParticle* part, double length, doubl
             x  = res[0];
             xp = res[1];
             free(res);
-            if (x <= 0) {
-                s = rlen0 - rlen + s;
-                break; // go to 20
+            if (x < 0) {
+                // extrapolation back to where x = 0
+                s = rlen0 - rlen + (s - x/tan(xp * M_PI  / 180.0));
+                x = 0.0;
+                break;
             }
             if (s + dh >= rlen) {
                 s = rlen0;
-                break; // go to 20
+                break;
             }
-            // go to 10
             rlen = rlen - s;
         }
 


### PR DESCRIPTION
## Description
Added extrapolation to make sure x and s has the correct values after mcs with edge effects. 
Fixed bug by changing amorphous transport to amorphous. 
Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
