### PR TITLE
Import Geant4Collimator in `initial_distribution.py`

### DIFF
--- a/xcoll/initial_distribution.py
+++ b/xcoll/initial_distribution.py
@@ -10,7 +10,7 @@ import xtrack as xt
 import xobjects as xo
 import xpart as xp
 
-from .beam_elements import _all_collimator_classes, EverestCrystal
+from .beam_elements import _all_collimator_classes, EverestCrystal, Geant4Collimator
 
 
 def generate_pencil_on_collimator(line, name, num_particles, *, side='+-', pencil_spread=1e-6,


### PR DESCRIPTION
## Description
This pull request fixes an issue in `initial_distribution.py` where `Geant4Collimator` was not imported, causing a `NameError` during the execution of the `generate_pencil_on_collimator` function. 

Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
