### PR TITLE
Release 0.5.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xcoll"
-version = "0.5.7"
+version = "0.5.8rc0"
 description = "Xsuite collimation package"
 homepage = "https://github.com/xsuite/xcoll"
 repository = "https://github.com/xsuite/xcoll"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xcoll"
-version = "0.5.8rc0"
+version = "0.5.8"
 description = "Xsuite collimation package"
 homepage = "https://github.com/xsuite/xcoll"
 repository = "https://github.com/xsuite/xcoll"

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@
 from xcoll import __version__
 
 def test_version():
-    assert __version__ == '0.5.7'
+    assert __version__ == '0.5.8rc0'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@
 from xcoll import __version__
 
 def test_version():
-    assert __version__ == '0.5.8rc0'
+    assert __version__ == '0.5.8'

--- a/xcoll/beam_elements/elements_src/everest_crystal.h
+++ b/xcoll/beam_elements/elements_src/everest_crystal.h
@@ -138,6 +138,7 @@ EverestCollData EverestCrystal_init(EverestCrystalData el, LocalParticle* part0,
         coll->csref[0] = CrystalMaterialData_get_cross_section(material, 0);
         coll->csref[1] = CrystalMaterialData_get_cross_section(material, 1);
         coll->csref[5] = CrystalMaterialData_get_cross_section(material, 5);
+        coll->only_mcs = CrystalMaterialData_get__only_mcs(material);
         coll->dlri     = CrystalMaterialData_get_crystal_radiation_length(material);
         coll->dlyi     = CrystalMaterialData_get_crystal_nuclear_length(material);
         coll->ai       = CrystalMaterialData_get_crystal_plane_distance(material);

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -12,5 +12,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ======================
 # Do not change
 # ======================
-__version__ = '0.5.8rc0'
+__version__ = '0.5.8'
 # ======================

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -12,5 +12,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ======================
 # Do not change
 # ======================
-__version__ = '0.5.7'
+__version__ = '0.5.8rc0'
 # ======================

--- a/xcoll/interaction_record/interaction_record.py
+++ b/xcoll/interaction_record/interaction_record.py
@@ -238,14 +238,14 @@ class InteractionRecord(xt.BeamElement):
                     'int':  [shortcuts[inter] for inter in self._inter[mask]],
                     'pid':  self.id_before[mask]
                 })
-            return df.groupby('pid', sort=False)['int'].agg(list)
+            return df.groupby('pid', sort=False, group_keys=False)['int'].agg(list)
         else:
             df = pd.DataFrame({
                     'int':   [shortcuts[inter] for inter in self._inter[mask]],
                     'turn':  self.at_turn[mask],
                     'pid':   self.id_before[mask]
                 })
-            return df.groupby(['pid', 'turn'], sort=False)['int'].apply(list)
+            return df.groupby(['pid', 'turn'], sort=False, group_keys=False)['int'].apply(list)
 
     def first_touch_per_turn(self, frame=None):
         n_rows = self._index.num_recorded
@@ -253,7 +253,8 @@ class InteractionRecord(xt.BeamElement):
                            'at_turn': self.at_turn[:n_rows],
                            'at_element': self.at_element[:n_rows]})
         mask = np.char.startswith(self.interaction_type[:n_rows], 'Enter Jaw')
-        idx_first = [group.at_element.idxmin() for _, group in df[mask].groupby(['at_turn', 'id_before'], sort=False)]
+        idx_first = [group.at_element.idxmin() for _, group in df[mask].groupby(
+                        ['at_turn', 'id_before'], sort=False, group_keys=False)]
         df_first = self.to_pandas(frame=frame).loc[idx_first]
         df_first.insert(2, "jaw", df_first.interaction_type.astype(str).str[-1])
         to_drop = ['interaction_type',


### PR DESCRIPTION
- **Created release branch release/v0.5.8rc0.**
- **Important bugfix: the only_mcs flag was not set for crystals. Hence, when it was being tested it often wrongly evaluated to True, making the rest of the code being skipped (where the other material parameters were defined and then hence then became garbage).**
- **Adapted df.groupby in interaction_record to be future-proof with pandas**
- **Updated version number to v0.5.8.**
