### PR TITLE
Boxes WIP

### DIFF
--- a/xcoll/geometry/segments/bezier.py
+++ b/xcoll/geometry/segments/bezier.py
@@ -59,10 +59,12 @@ class BezierSegment(xo.Struct):
         kwargs['_cx1'] = cx1
         kwargs['_cs2'] = cs2
         kwargs['_cx2'] = cx2
+        t1 = kwargs.pop('t1', 0.)
+        t2 = kwargs.pop('t2', 1.)
         super().__init__(**kwargs)
         self.calculate_extrema()
         self.box = BoundingBox()
-        self.init_bounding_box(box=self.box, t1=0., t2=1.)
+        self.init_bounding_box(box=self.box, t1=t1, t2=t2)
 
     def __str__(self):
         return f"BezierSegment(({self.s1:.3}, {self.x1:.3})-c-({self.cs1:.3}, {self.cx1:.3}) -- " \

--- a/xcoll/geometry/segments/circular.h
+++ b/xcoll/geometry/segments/circular.h
@@ -62,6 +62,7 @@ void CircularSegment_init_bounding_box(CircularSegment seg, BoundingBox box, dou
         tt1 -= 2*M_PI;
         tt2 -= 2*M_PI;
     }
+    printf("tt1 = %.20f, tt2 = %.20f\n", tt1, tt2);
     double s1 = CircularSegment_func_s(seg, t1);
     double x1 = CircularSegment_func_x(seg, t1);
     double s2 = CircularSegment_func_s(seg, t2);
@@ -77,34 +78,53 @@ void CircularSegment_init_bounding_box(CircularSegment seg, BoundingBox box, dou
     double sin_rot, cos_rot;
     double l, w;
     double rotate_box = -1.;
-    int8_t sign = 1;                                           // The orientation of the box can impact calculations
-    if ((cos_chord > 1e-10) && (sin_chord > 1e-10)){           // if 0 < chord angle < 90 deg, then chord angle = box angle
+    int8_t sign = 1;                                             // The orientation of the box can impact calculations
+    printf("s1 = %f, s2 = %f\n", s1, s2);
+    printf("x1 = %f, x2 = %f\n", x1, x2);
+    if (((cos_chord > 1e-10) && (sin_chord > 1e-10))){           // if 0 < chord angle < 90 deg, then chord angle = box angle
         sin_t = sin_chord;
         cos_t = cos_chord;
         sin_rot = -cos_t;
         cos_rot = sin_t;
         sign = -1;
+        printf("first if\n");
     } else {
         if (sin_chord < 1e-10) {                               // if theta is larger than 180 degrees, theta = theta - 180
             sin_chord = -sin_chord;
             cos_chord = -cos_chord;
+            printf("over 180 degrees\n");
         }
-        if ((cos_chord > 1e-10) && (sin_chord > 1e-10)){       // if 0 < chord angle < 90 deg, then chord angle = box angle
+        printf("coschord = %f, sinchord = %f\n", cos_chord, sin_chord);
+        if ( ((cos_chord > 1e-10) && (sin_chord > 1e-10))){       // if 0 < chord angle < 90 deg, then chord angle = box angle
             sin_t = sin_chord;
             cos_t = cos_chord;
             sin_rot = -cos_t;
             cos_rot = sin_t;
             sign = -1;
+            printf("second if\n");
+        } else if ((((cos_chord - 1.) < 1e-10) || ((cos_chord + 1.) > -1e-10)) && ((sin_chord < 1e-10) && (sin_chord > -1e-10))){
+            // FREDERIK: IT IS THESE ANGLES. problem is here.
+            sin_t = sin_chord;  // if cos_chord is 1 or -1, then box angle = chord angle
+            cos_t = cos_chord;
+            sin_rot = -cos_t;
+            cos_rot = sin_t;
+            sign = -1;
+            printf("am i here ????\n");
         } else {
-            sin_t = - cos_chord;                               // box angle is 90 degrees less than chord angle
+            sin_t = -cos_chord;                               // box angle is 90 degrees less than chord angle
             cos_t = sin_chord;
             sin_rot = sin_t;    
             cos_rot = cos_t;
             sign = -1;
+            printf("third if\n");
         } 
     }
-    if ((tt2 - tt1) < M_PI){                                   // delta theta of box less than 180.
+    printf("chord_length = %f\n", chord_length);
+    printf("R = %f\n", R);
+    printf("tt2 - tt1 = %.20f\n", (tt2 - tt1));
+    if ((tt2 - tt1) <= M_PI){                                   // delta theta of box less than 180.
         w = R - sqrt(R*R - chord_length*chord_length/4.);      // sagitta
+        printf("here w = %f\n", w);
         l = chord_length;
         if (cos_chord > 0){
             rotate_box = -1;
@@ -113,20 +133,41 @@ void CircularSegment_init_bounding_box(CircularSegment seg, BoundingBox box, dou
         }
         // finding the first vertex. 
         if (x1 < x2){
-            if (((tt1 < M_PI && tt2 > M_PI) && (cos_chord < 0)) || (( (-M_PI < tt1) && (tt1 < 0.) ) && ( (-M_PI < tt2) && (tt2 < 0.))) || ((tt1 < 0 && tt2 > 0) && (cos_chord > 0))){                // t1 or t2 is lower vertex
+            //FREDERIK THE PROBLEM IS SEEN HERE
+            printf("here x1 < x2\n");
+            printf("sin_rot = %f, cos_rot = %f\n", sin_rot, cos_rot);
+            if (((tt1 <= M_PI && tt2 > M_PI) && (cos_chord < 0)) || (( (-M_PI <= tt1) && (tt1 < 0.) ) && ( (-M_PI <= tt2) && (tt2 < 0.))) || ((tt1 <= 0 && tt2 > 0) && (cos_chord > 0))){                // t1 or t2 is lower vertex
                 BoundingBox_set_rC(box,( sqrt( ((s1)+w*cos_rot)*((s1)+w*cos_rot) +
                                                ((x1)+w*sin_rot)*((x1)+w*sin_rot)) ));
                 double rC = BoundingBox_get_rC(box);
                 BoundingBox_set_sin_tC(box,((x1)+w*sin_rot) / rC);
                 BoundingBox_set_cos_tC(box,((s1)+w*cos_rot) / rC);
             } else {
+                printf("here tho?\n");
                 double rC = (sqrt((s1)*(s1) + (x1)*(x1)));
+                printf("RC = %f\n", rC);
+                printf("sintC = %f\n", (x1) / rC);
+                printf("costC = %f\n", (s1) / rC);
+                printf("sintb = %f\n", sin_t);
+                printf("costb = %f\n", cos_t);
+                printf("s1: rC*cos_tc = %f\n", rC*s1/rC);
+                printf("x1:rC*sin_tc = %f\n", rC*x1/rC);
+                printf("s2: rC*cos_tc +l*costb = %f\n", rC*s1/rC + l*cos_t);
+                printf("s2 (min cos): rC*cos_tc -l*costb = %f\n", rC*s1/rC - l*cos_t);
+                printf("x2: rC*sin_tc +l*sintb = %f\n", rC*x1/rC + l*sin_t);
+                printf("s3: rC*cos_tc +l*costb - w*sin_t = %f\n", rC*s1/rC + l*cos_t - w*sin_t);
+                printf("s3(min cos): rC*cos_tc -l*costb - w*sin_t = %f\n", rC*s1/rC - l*cos_t - w*sin_t);
+                printf("x3: rC*sin_tc +l*sintb + w*cos_t = %f\n", rC*x1/rC + l*sin_t + w*cos_t);
+                printf("x3 (min cos): rC*sin_tc +l*sintb - w*cos_t = %f\n", rC*x1/rC + l*sin_t - w*cos_t);
+                printf("s4: rC*cos_tc - w*sin_t = %f\n", rC*s1/rC  - w*sin_t);
+                printf("x4: rC*sin_tc + w*cos_t = %f\n", rC*x1/rC  + w*cos_t);
+                printf("x4 (min cos): rC*sin_tc - w*cos_t = %f\n", rC*x1/rC  - w*cos_t);
                 BoundingBox_set_rC(box, rC);
                 BoundingBox_set_sin_tC(box, (x1) /rC);
                 BoundingBox_set_cos_tC(box, (s1) /rC);
             }
         } else {
-            if (((tt1 < M_PI && tt2 > M_PI) && (cos_chord < 0)) || (( (-M_PI < tt1) && (tt1 < 0.) ) && ( (-M_PI < tt2) && (tt2 < 0.))) || ((tt1 < 0 && tt2 > 0) && (cos_chord > 0))){                // t1 or t2 is lower vertex
+            if (((tt1 <= M_PI && tt2 >= M_PI) && (cos_chord < 0)) || (( (-M_PI <= tt1) && (tt1 <= 0.) ) && ( (-M_PI <= tt2) && (tt2 <= 0.))) || ((tt1 <= 0 && tt2 >= 0) && (cos_chord > 0))){                // t1 or t2 is lower vertex
                 BoundingBox_set_rC(box, (sqrt( ((s2)-w*cos_rot)*((s2)-w*cos_rot) +
                                               ((x2)-w*sin_rot)*((x2)-w*sin_rot)) ));
                 BoundingBox_set_sin_tC(box, (((x2)-w*sin_rot)) / BoundingBox_get_rC(box));
@@ -144,8 +185,10 @@ void CircularSegment_init_bounding_box(CircularSegment seg, BoundingBox box, dou
         w = (R + sqrt(R*R - (chord_length*chord_length/4.))); // 2R - sagitta
         double chord_side_w1_x, chord_side_w1_s, chord_side_w2_x, chord_side_w2_s;
         double w3_x, w3_s, w4_x, w4_s;
+        printf("x1, x2 = %f, %f\n", x1, x2);
         // determining the (s,x) of the vertices on the chord side of box
-        if (x1 < x2){
+        if ((x2-x1) > 1e-10){
+            printf("sign = %d\n", sign);
             rotate_box = 1;
             chord_side_w1_x = x1 - (2*R - chord_length)/2.*sin_chord;
             chord_side_w1_s = s1 - (2*R - chord_length)/2.*cos_chord;
@@ -155,6 +198,7 @@ void CircularSegment_init_bounding_box(CircularSegment seg, BoundingBox box, dou
             w3_s = chord_side_w1_s + w*cos_rot;
             w4_x = chord_side_w2_x - sign*w*sin_rot;
             w4_s = chord_side_w2_s + w*cos_rot;
+            printf("here?????\n");
         } else {
             rotate_box = -1;
             chord_side_w2_x = x2 - (2*R - chord_length)/2.*sin_chord;
@@ -167,9 +211,18 @@ void CircularSegment_init_bounding_box(CircularSegment seg, BoundingBox box, dou
             w4_s = chord_side_w2_s - w*cos_rot;
         }
         // Compare with the other three points to find the first vertex. Also taking into account if the box is horiztonal
+        printf("w3_x, w3_s = %f, %f\n", w3_x, w3_s);
+        printf("w4_x, w4_s = %f, %f\n", w4_x, w4_s);
+        printf("chord_side_w1_x, chord_side_w1_s = %f, %f\n", chord_side_w1_x, chord_side_w1_s);
+        printf("chord_side_w2_x, chord_side_w2_s = %f, %f\n", chord_side_w2_x, chord_side_w2_s);
+        printf("rotate_box = %f\n", rotate_box);
+        printf("cos_t = %f, sin_t = %f\n", cos_t, sin_t);
+        printf("cos_rot = %f, sin_rot = %f\n", cos_rot, sin_rot);
+        printf("l = %f, w = %f\n", l, w);
+        printf("cos_chord = %f, sin_chord = %f\n", cos_chord, sin_chord);
         min_x = chord_side_w1_x;
         min_s = chord_side_w1_s;
-        if ((chord_side_w2_x < min_x) || (chord_side_w2_x == min_x && chord_side_w2_s < min_s)) {
+        if ((chord_side_w2_x < min_x) || (((chord_side_w2_x-min_x)<1e-10) && (chord_side_w2_s < min_s))) {
             if ((chord_side_w2_x < min_x) && (chord_side_w2_s > min_s)) {
                 rotate_box = 1;
             } else {
@@ -178,7 +231,7 @@ void CircularSegment_init_bounding_box(CircularSegment seg, BoundingBox box, dou
             min_x = chord_side_w2_x; 
             min_s = chord_side_w2_s;
         }
-        if (w3_x < min_x || (w3_x == min_x && w3_s < min_s)) {
+        if (w3_x < min_x || (((w3_x-min_x)<1e-10) && (w3_s < min_s))) {
             min_x = w3_x; 
             min_s = w3_s;   
             rotate_box = -1;
@@ -192,6 +245,7 @@ void CircularSegment_init_bounding_box(CircularSegment seg, BoundingBox box, dou
         BoundingBox_set_sin_tC(box, min_x / BoundingBox_get_rC(box));
         BoundingBox_set_cos_tC(box, min_s / BoundingBox_get_rC(box));
     }
+    printf("rotate_box = %f\n", rotate_box);
     if (rotate_box == -1){
         BoundingBox_set_l(box, l);   // length of the box
         BoundingBox_set_w(box, w);   // width of the box

--- a/xcoll/geometry/segments/circular.py
+++ b/xcoll/geometry/segments/circular.py
@@ -125,6 +125,8 @@ class CircularSegment(xo.Struct):
         t2 = kwargs.pop('t2', 2*np.pi)
         super().__init__(**kwargs)
         self.set_angles(theta1, theta2)
+        print("theta1", self._theta1)
+        print("theta2", self._theta2)
         self.box = BoundingBox()
         self.init_bounding_box(box=self.box, t1=t1, t2=t2)
 

--- a/xcoll/geometry/segments/halfopen_line.h
+++ b/xcoll/geometry/segments/halfopen_line.h
@@ -51,24 +51,20 @@ void HalfOpenLineSegment_init_bounding_box(HalfOpenLineSegment seg, BoundingBox 
     double x2 = HalfOpenLineSegment_func_x(seg, t2);
     double sin_t = HalfOpenLineSegment_get_sin_t1(seg); // angle of the line wrt horizontal
     double cos_t = HalfOpenLineSegment_get_cos_t1(seg);
-    double sin_p, cos_p;
-    if (cos_t < 1){   // if theta is larger than 90 degrees, phi = theta + 90 
-        sin_p = cos_t;
-        cos_p = -sin_t;
-    } else {          // if theta is between 0 and 90 degrees, phi = theta - 90
-        sin_p = -cos_t;
-        cos_p = sin_t;
-    }
     BoundingBox_set_l(box, sqrt((s2 - s1)*(s2 - s1) + (x2 - x1)*(x2 - x1)));    // length of the box
-    BoundingBox_set_w(box, 0.001);      // width of the box 
+    BoundingBox_set_w(box, 0.0);      // width of the box 
     double w = BoundingBox_get_w(box);                                     
-    BoundingBox_set_rC(box, sqrt( (s1+w/2.*cos_p)*(s1+w/2.*cos_p) + // length of the position vector to the first vertex
-                                  (x1+w/2.*sin_p)*(x1+w/2.*sin_p) ));
+    BoundingBox_set_rC(box, sqrt(s1*s1 + x1*x1)); // length of the position vector to the first vertex
     double rC = BoundingBox_get_rC(box);
     BoundingBox_set_sin_tb(box, sin_t);  // orientation of the box (angle of length wrt horizontal)
     BoundingBox_set_cos_tb(box, cos_t);
-    BoundingBox_set_sin_tC(box, x1 / rC);  // angle of the position vector to the first vertex
-    BoundingBox_set_cos_tC(box, s1 / rC);
+    if (BoundingBox_get_rC(box) == 0.){
+        BoundingBox_set_sin_tC(box, 0.0);  // angle of the position vector to the first vertex
+        BoundingBox_set_cos_tC(box, 1.0);
+    } else {
+        BoundingBox_set_sin_tC(box, x1 / rC);  // angle of the position vector to the first vertex
+        BoundingBox_set_cos_tC(box, s1 / rC);
+    }
     BoundingBox_set_proj_l(box, rC * (cos_t*s1/rC + sin_t*x1/rC)); // projection of the position vector on length: rC * (cos_t*cos_tC + sin_t*sin_tC)
     BoundingBox_set_proj_w(box, rC * (cos_t*x1/rC - sin_t*s1/rC)); // projection of position vector on width: rC * (cos_t*sin_tC - sin_t*cos_tC)
 }

--- a/xcoll/geometry/segments/halfopen_line.h
+++ b/xcoll/geometry/segments/halfopen_line.h
@@ -51,11 +51,7 @@ void HalfOpenLineSegment_init_bounding_box(HalfOpenLineSegment seg, BoundingBox 
     double x2 = HalfOpenLineSegment_func_x(seg, t2);
     double sin_t = HalfOpenLineSegment_get_sin_t1(seg); // angle of the line wrt horizontal
     double cos_t = HalfOpenLineSegment_get_cos_t1(seg);
-    double sin_p, cos_p; 
-    //if (sin_t < 0){   // if theta is larger than 180 degrees, theta = theta - 180
-    //    sin_t = -sin_t;
-    //    cos_t = -cos_t;
-   // }
+    double sin_p, cos_p;
     if (cos_t < 1){   // if theta is larger than 90 degrees, phi = theta + 90 
         sin_p = cos_t;
         cos_p = -sin_t;

--- a/xcoll/geometry/segments/line.h
+++ b/xcoll/geometry/segments/line.h
@@ -48,17 +48,13 @@ void LineSegment_init_bounding_box(LineSegment seg, BoundingBox box, double t1, 
     //Calculate the bounding box of a line segment.
     //Theta is the angle of the line wrt the horizontal. 
     //Phi is the angle from s1 to the first vertex (in the frame of the box).
-    double s1 = LineSegment_get_s1(seg);
-    double s2 = LineSegment_get_s2(seg);
-    double x1 = LineSegment_get_x1(seg);
-    double x2 = LineSegment_get_x2(seg);
+    double s1 = LineSegment_func_s(seg, t1);
+    double s2 = LineSegment_func_s(seg, t2);
+    double x1 = LineSegment_func_x(seg, t1);
+    double x2 = LineSegment_func_x(seg, t2);
     double sin_t = (x2 - x1) / sqrt((x2 - x1)*(x2 - x1) + (s2 - s1)*(s2 - s1));
     double cos_t = (s2 - s1) / sqrt((x2 - x1)*(x2 - x1) + (s2 - s1)*(s2 - s1));
-    double sin_p, cos_p; 
-    if (sin_t < 0){   // if theta is larger than 180 degrees, theta = theta - 180
-        sin_t = -sin_t;
-        cos_t = -cos_t;
-    }
+    double sin_p, cos_p;
     if (cos_t < 1){   // if theta is larger than 90 degrees, phi = theta + 90 
         sin_p = cos_t;
         cos_p = -sin_t;

--- a/xcoll/geometry/segments/line.h
+++ b/xcoll/geometry/segments/line.h
@@ -54,22 +54,18 @@ void LineSegment_init_bounding_box(LineSegment seg, BoundingBox box, double t1, 
     double x2 = LineSegment_func_x(seg, t2);
     double sin_t = (x2 - x1) / sqrt((x2 - x1)*(x2 - x1) + (s2 - s1)*(s2 - s1));
     double cos_t = (s2 - s1) / sqrt((x2 - x1)*(x2 - x1) + (s2 - s1)*(s2 - s1));
-    double sin_p, cos_p;
-    if (cos_t < 1){   // if theta is larger than 90 degrees, phi = theta + 90 
-        sin_p = cos_t;
-        cos_p = -sin_t;
-    } else {          // if theta is between 0 and 90 degrees, phi = theta - 90
-        sin_p = -cos_t;
-        cos_p = sin_t;
-    }
     BoundingBox_set_l(box, sqrt((s2 - s1)*(s2 - s1) + (x2 - x1)*(x2 - x1)));   // length of the box
-    BoundingBox_set_w(box, 0.001);       // width of the box cannot be 0 for (0,0)
-    BoundingBox_set_rC(box, sqrt( (s1+BoundingBox_get_w(box)/2.*cos_p) * (s1+BoundingBox_get_w(box)/2.*cos_p) +  // length of the position vector to the first vertex
-                                  (x1+BoundingBox_get_w(box)/2.*sin_p) * (x1+BoundingBox_get_w(box)/2.*sin_p) ));
+    BoundingBox_set_w(box, 0.);       // width of the box cannot be 0 for (0,0)
+    BoundingBox_set_rC(box,sqrt(s1*s1 + x1*x1)); // length of the position vector to the first vertex
     BoundingBox_set_sin_tb(box, sin_t);  // orientation of the box (angle of length wrt horizontal)
     BoundingBox_set_cos_tb(box, cos_t);
-    BoundingBox_set_sin_tC(box, x1 / BoundingBox_get_rC(box));  // angle of the position vector to the first vertex
-    BoundingBox_set_cos_tC(box, s1 / BoundingBox_get_rC(box));
+    if (BoundingBox_get_rC(box) == 0.0){
+        BoundingBox_set_sin_tC(box, 0.0); // angle of the position vector to the first vertex
+        BoundingBox_set_cos_tC(box, 1.0);
+    } else {
+        BoundingBox_set_sin_tC(box, x1 / BoundingBox_get_rC(box));  // angle of the position vector to the first vertex
+        BoundingBox_set_cos_tC(box, s1 / BoundingBox_get_rC(box));
+    }
     double sin_tC = BoundingBox_get_sin_tC(box);
     double cos_tC = BoundingBox_get_cos_tC(box);
     BoundingBox_set_proj_l(box, BoundingBox_get_rC(box) * (cos_t*cos_tC + sin_t*sin_tC)); // projection of the position vector on length: rC * (cos_t*cos_tC + sin_t*sin_tC)

--- a/xcoll/geometry/segments/line.py
+++ b/xcoll/geometry/segments/line.py
@@ -29,10 +29,6 @@ class LineSegment(xo.Struct):
                                         ret=None)}
 
     def __init__(self, *args, **kwargs):
-        if ((kwargs['s2'] < kwargs['s1']) and (kwargs['x2'] < kwargs['x1'])) or (
-            (kwargs['s2'] > kwargs['s1']) and (kwargs['x2'] < kwargs['x1']) ):
-            kwargs['s1'], kwargs['s2'] = kwargs['s2'], kwargs['s1']
-            kwargs['x1'], kwargs['x2'] = kwargs['x2'], kwargs['x1']
         t1 = kwargs.pop('t1', 0.)
         t2 = kwargs.pop('t2', 1.)
         super().__init__(*args, **kwargs)

--- a/xcoll/geometry/trajectories/circular.h
+++ b/xcoll/geometry/trajectories/circular.h
@@ -100,11 +100,11 @@ void CircularTrajectory_init_bounding_box(CircularTrajectory traj, BoundingBox b
     double cos_chord = ds / chord_length;
     double sin_t, cos_t;                                       // angle of the box wrt horizontal
     double min_x, min_s;   
-    double sin_rot, cos_rot;
+    double sin_rot, cos_rot;                                   // angle of rotation
     double l, w;
     double rotate_box = -1.;
     int8_t sign = 1;                                           // The orientation of the box can impact calculations
-    if ((cos_chord > 1e-10) && (sin_chord > 1e-10)){           // if 0 < chord angle < 90 deg, then chord angle = box angle
+    if (((cos_chord > 1e-10) && (sin_chord > 1e-10))){           // if 0 < chord angle < 90 deg, then chord angle = box angle
         sin_t = sin_chord;
         cos_t = cos_chord;
         sin_rot = -cos_t;
@@ -115,7 +115,14 @@ void CircularTrajectory_init_bounding_box(CircularTrajectory traj, BoundingBox b
             sin_chord = -sin_chord;
             cos_chord = -cos_chord;
         }
-        if ((cos_chord > 1e-10) && (sin_chord > 1e-10)){       // if 0 < chord angle < 90 deg, then chord angle = box angle
+        if ( ((cos_chord > 1e-10) && (sin_chord > 1e-10))){       // if 0 < chord angle < 90 deg, then chord angle = box angle
+            sin_t = sin_chord;
+            cos_t = cos_chord;
+            sin_rot = -cos_t;
+            cos_rot = sin_t;
+            sign = -1;
+        } else if (((((cos_chord - 1.) < 1e-10) || ((cos_chord + 1.) > -1e-10)) && (sin_chord < 1e-10)) ||
+                     ((cos_chord < 1e-10) && (((sin_chord-1.) < 1e-10) || ((sin_chord+1) > -1e-10)))){
             sin_t = sin_chord;
             cos_t = cos_chord;
             sin_rot = -cos_t;
@@ -171,7 +178,7 @@ void CircularTrajectory_init_bounding_box(CircularTrajectory traj, BoundingBox b
         double chord_side_w1_x, chord_side_w1_s, chord_side_w2_x, chord_side_w2_s;
         double w3_x, w3_s, w4_x, w4_s;
         // determining the (s,x) of the vertices on the chord side of box
-        if (x1 < x2){
+        if ((x2-x1) > 1e-10){
             rotate_box = 1;
             chord_side_w1_x = x1 - (2*R - chord_length)/2.*sin_chord;
             chord_side_w1_s = s1 - (2*R - chord_length)/2.*cos_chord;
@@ -195,7 +202,7 @@ void CircularTrajectory_init_bounding_box(CircularTrajectory traj, BoundingBox b
         // Compare with the other three points to find the first vertex. Also taking into account if the box is horiztonal
         min_x = chord_side_w1_x;
         min_s = chord_side_w1_s;
-        if ((chord_side_w2_x < min_x) || (chord_side_w2_x == min_x && chord_side_w2_s < min_s)) {
+        if ((chord_side_w2_x < min_x) || (((chord_side_w2_x - min_x) < 1e-10) && (chord_side_w2_s < min_s))) {
             if ((chord_side_w2_x < min_x) && (chord_side_w2_s > min_s)) {
                 rotate_box = 1;
             } else {
@@ -204,12 +211,12 @@ void CircularTrajectory_init_bounding_box(CircularTrajectory traj, BoundingBox b
             min_x = chord_side_w2_x; 
             min_s = chord_side_w2_s;
         }
-        if (w3_x < min_x || (w3_x == min_x && w3_s < min_s)) {
+        if (w3_x < min_x || (((w3_x - min_x) < 1e-10) && (w3_s < min_s))) {
             min_x = w3_x; 
             min_s = w3_s;   
             rotate_box = -1;
         }
-        if (w4_x < min_x || (((w4_x - min_x)<1e-10) && w4_s <= min_s)) {
+        if (w4_x < min_x || (((w4_x - min_x)<1e-10) && (w4_s <= min_s))) {
             min_x = w4_x; 
             min_s = w4_s;
             rotate_box = 1;

--- a/xcoll/geometry/trajectories/drift.h
+++ b/xcoll/geometry/trajectories/drift.h
@@ -64,9 +64,9 @@ double DriftTrajectory_deriv_x(DriftTrajectory traj, double l){
 
 /*gpufun*/
 void DriftTrajectory_init_bounding_box(DriftTrajectory traj, BoundingBox box, double l1, double l2){
-    double s1 = DriftTrajectory_get_s0(traj);
+    double s1 = DriftTrajectory_func_s(traj, l1);
     double s2 = DriftTrajectory_func_s(traj, l2);
-    double x1 = DriftTrajectory_get_x0(traj);
+    double x1 = DriftTrajectory_func_x(traj, l1);
     double x2 = DriftTrajectory_func_x(traj, l2);
     double sin_t0 = DriftTrajectory_get_sin_t0(traj);
     double cos_t0 = DriftTrajectory_get_cos_t0(traj);

--- a/xcoll/geometry/trajectories/drift.h
+++ b/xcoll/geometry/trajectories/drift.h
@@ -70,16 +70,18 @@ void DriftTrajectory_init_bounding_box(DriftTrajectory traj, BoundingBox box, do
     double x2 = DriftTrajectory_func_x(traj, l2);
     double sin_t0 = DriftTrajectory_get_sin_t0(traj);
     double cos_t0 = DriftTrajectory_get_cos_t0(traj);
-    double sin_p  = -cos_t0;  // phi = theta - 90 deg.
-    double cos_p  = sin_t0;
     BoundingBox_set_l(box, sqrt((s2 - s1)*(s2 - s1) + (x2 - x1)*(x2 - x1)));   // length of the box
     BoundingBox_set_w(box, 0.);       // width of the box 
-    BoundingBox_set_rC(box, sqrt( (s1+BoundingBox_get_w(box)/2.*cos_p) * (s1+BoundingBox_get_w(box)/2.*cos_p) +  // length of the position vector to the first vertex
-                                   (x1+BoundingBox_get_w(box)/2.*sin_p) * (x1+BoundingBox_get_w(box)/2.*sin_p) ));
+    BoundingBox_set_rC(box, sqrt(s1*s1 + x1*x1));
     BoundingBox_set_sin_tb(box, sin_t0);  // orientation of the box (angle of length wrt horizontal)
     BoundingBox_set_cos_tb(box, cos_t0);
-    BoundingBox_set_sin_tC(box, x1 / BoundingBox_get_rC(box));  // angle of the position vector to the first vertex
-    BoundingBox_set_cos_tC(box, s1 / BoundingBox_get_rC(box));
+    if (BoundingBox_get_rC(box) == 0.){
+        BoundingBox_set_sin_tC(box, 0.0);  // angle of the position vector to the first vertex
+        BoundingBox_set_cos_tC(box, 1.0);
+    } else {
+        BoundingBox_set_sin_tC(box, x1 / BoundingBox_get_rC(box));  // angle of the position vector to the first vertex
+        BoundingBox_set_cos_tC(box, s1 / BoundingBox_get_rC(box));
+    }
     double sin_tC = BoundingBox_get_sin_tC(box);
     double cos_tC = BoundingBox_get_cos_tC(box);
     BoundingBox_set_proj_l(box, BoundingBox_get_rC(box) * (cos_t0*cos_tC + sin_t0*sin_tC)); // projection of the position vector on length: rC * (cos_t*cos_tC + sin_t*sin_tC)

--- a/xcoll/geometry/trajectories/mcs.h
+++ b/xcoll/geometry/trajectories/mcs.h
@@ -130,13 +130,18 @@ void MultipleCoulombTrajectory_init_bounding_box(MultipleCoulombTrajectory traj,
     if (shift_x >= 0) {
         s1 = MultipleCoulombTrajectory_func_s(traj, l1);
         x1 = MultipleCoulombTrajectory_func_x(traj, l1);
+        printf("x1, s1 = %f, %f\n", x1, s1);
     } else {
         // Different lower left corner
         double s0 = MultipleCoulombTrajectory_get_s0(traj);
         double x0 = MultipleCoulombTrajectory_get_x0(traj);
         s1 = s0 + l1*cos_t0 - l2*A0*omega_norm*sin_t0;
         x1 = x0 + l1*sin_t0 + l2*A0*omega_norm*cos_t0;
+        printf("s0, x0 = %f, %f\n", s0, x0);
+        printf("x1, s1 = %f, %f\n", x1, s1);
     }
+    double s2 = MultipleCoulombTrajectory_func_s(traj, l2);
+    double x2 = MultipleCoulombTrajectory_func_x(traj, l2);
     BoundingBox_set_rC(box, sqrt(s1*s1 + x1*x1)); // length of position vector to first vertex
     double rC = BoundingBox_get_rC(box);
     BoundingBox_set_sin_tC(box, x1 / rC);    // angle of position vector to first vertex
@@ -146,7 +151,8 @@ void MultipleCoulombTrajectory_init_bounding_box(MultipleCoulombTrajectory traj,
     BoundingBox_set_proj_l(box, rC * (cos_t0*cos_tC + sin_t0*sin_tC)); // projection of position vector on length: rC * (cos_t*cos_tC + sin_t*sin_tC)
     BoundingBox_set_proj_w(box, rC * (cos_t0*sin_tC - sin_t0*cos_tC)); // projection of position vector on width:  rC * (cos_t*sin_tC - sin_t*cos_tC)
     BoundingBox_set_l(box, l2 - l1);       // length of the box
-    BoundingBox_set_w(box, fabs(shift_x)); // width of the box
+    //BoundingBox_set_w(box, fabs(shift_x)); // width of the box
+    BoundingBox_set_w(box, sqrt((s2-s1)*(s2-s1) + (x2-x1)*(x2-x1))); // width of the box
     BoundingBox_set_sin_tb(box, sin_t0);   // orientation of the box (angle of length wrt horizontal)
     BoundingBox_set_cos_tb(box, cos_t0);
 }


### PR DESCRIPTION
## Description
Problems:
* The mcs has a problem with the width when l1 != 0. In the other seg/traj it was because we got s1, ... directly without getting it from func_s(seg, l1). I cannot see anything like that here.
* Circle: It works wonderfully except at 2 pi (should be an easy fix, probably related to the bigger problem). Bigger problem is when the angles are exactly from 0, pi. or -pi, 0. It manages 180 deg perfectly in any other case. It seems to be a problem with how the angles are set in the beginning. The code further down must be correct, because it is general, and works for all other cases. When I change the sus angle the x-coord of the vertices (which are printed) are correct, but suddenly the s is wrong. And vice versa. Idk why. Also, the box will look like it's even more wrong in the plotter, but this is because the way we generally define w and l in the bounding box class for the vertices does not always match with the circle, so at the end on the function I have to decide If I'm gonna send w=w or w = l etc. You'll see. It depends on the orientation of the segment/traj. So, often if something else is wrong, it will not rotate the box correctly in the plotter because of that. So instead you should look at the printout where I print the calculated vertices; they show the "true" box while debugging. 
Closes # .

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [ ] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
