### PR TITLE
Release 0.6.3

### DIFF
--- a/examples/lhc_run3_offmomentum_lossmap.py
+++ b/examples/lhc_run3_offmomentum_lossmap.py
@@ -59,10 +59,6 @@ line.build_tracker()
 line.collimators.assign_optics()
 
 
-# Optimise the line
-line.optimize_for_tracking()
-
-
 # Generate initial matched bunch
 part = xp.generate_matched_gaussian_bunch(nemitt_x=colldb.nemitt_x,
                                           nemitt_y=colldb.nemitt_y,
@@ -77,12 +73,13 @@ line.build_tracker(_context=xo.ContextCpu(omp_num_threads='auto'))
 
 # Print some info of the RF sweep
 rf_sweep = xc.RFSweep(line)
-rf_sweep.info(sweep=sweep, num_turns=num_turns)
+rf_sweep.prepare(sweep_per_turn=sweep/num_turns)
+rf_sweep.info()
 
 
 # Track during RF sweep:
 line.scattering.enable()
-rf_sweep.track(sweep=sweep, particles=part, num_turns=num_turns, time=True, with_progress=5)
+line.track(particles=part, num_turns=num_turns, time=True, with_progress=5)
 line.scattering.disable()
 print(f"Done sweeping RF in {line.time_last_track:.1f}s.")
 

--- a/examples/machines/sps_q20_inj.json
+++ b/examples/machines/sps_q20_inj.json
@@ -1,0 +1,37599 @@
+{
+ "elements": {
+  "vkicker": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0
+  },
+  "hkicker": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0
+  },
+  "tkicker": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0
+  },
+  "kicker": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0
+  },
+  "drift": {
+   "__class__": "Drift"
+  },
+  "collimator": {
+   "__class__": "Drift"
+  },
+  "rcollimator": {
+   "__class__": "Drift"
+  },
+  "ecollimator": {
+   "__class__": "Drift"
+  },
+  "instrument": {
+   "__class__": "Drift"
+  },
+  "monitor": {
+   "__class__": "Drift"
+  },
+  "hmonitor": {
+   "__class__": "Drift"
+  },
+  "vmonitor": {
+   "__class__": "Drift"
+  },
+  "placeholder": {
+   "__class__": "Drift"
+  },
+  "sbend": {
+   "__class__": "Bend",
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0,
+   "h": 0.0,
+   "length": 0.0,
+   "k0_from_h": false,
+   "angle": 0.0
+  },
+  "rbend": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0,
+   "h": 0.0,
+   "length": 0.0,
+   "k0_from_h": false,
+   "angle": 0.0,
+   "length_straight": 0.0
+  },
+  "quadrupole": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "sextupole": {
+   "__class__": "Sextupole",
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "octupole": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "marker": {
+   "__class__": "Marker"
+  },
+  "rfcavity": {
+   "__class__": "Cavity",
+   "_model": 0,
+   "_integrator": 0
+  },
+  "multipole": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "order": 5
+  },
+  "solenoid": {
+   "__class__": "UniformSolenoid",
+   "_integrator": 0,
+   "order": 5
+  },
+  "crabcavity": {
+   "__class__": "CrabCavity",
+   "_model": 0,
+   "_integrator": 0
+  },
+  "circle": {
+   "__class__": "Marker"
+  },
+  "ellipse": {
+   "__class__": "Marker"
+  },
+  "rectangle": {
+   "__class__": "Marker"
+  },
+  "rectellipse": {
+   "__class__": "Marker"
+  },
+  "racetrack": {
+   "__class__": "Marker"
+  },
+  "octagon": {
+   "__class__": "Marker"
+  },
+  "polygon": {
+   "__class__": "Marker"
+  },
+  "sps_bshv": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "sps_tacw": {
+   "__class__": "Drift",
+   "length": 0.848
+  },
+  "sps_tacw_002": {
+   "__class__": "Drift",
+   "length": 0.852
+  },
+  "sps_tal": {
+   "__class__": "Drift",
+   "length": 1.25
+  },
+  "sps_tbsjb": {
+   "__class__": "Drift",
+   "length": 2.1
+  },
+  "sps_tbsm": {
+   "__class__": "Drift",
+   "length": 2.0
+  },
+  "sps_tce": {
+   "__class__": "Drift",
+   "length": 2.7
+  },
+  "sps_tcpc": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "sps_tcsm": {
+   "__class__": "Drift",
+   "length": 1.83
+  },
+  "sps_tidp": {
+   "__class__": "Drift",
+   "length": 4.3
+  },
+  "sps_tidvg005": {
+   "__class__": "Drift",
+   "length": 5.0
+  },
+  "sps_tmadi": {
+   "__class__": "Drift",
+   "length": 1.34
+  },
+  "sps_tmasc001": {
+   "__class__": "Drift",
+   "length": 1.34
+  },
+  "sps_tmasc002": {
+   "__class__": "Drift",
+   "length": 1.34
+  },
+  "sps_tpsc4j": {
+   "__class__": "Drift",
+   "length": 1.3605
+  },
+  "sps_tpsg4": {
+   "__class__": "Drift",
+   "length": 3.098
+  },
+  "sps_tpsg6": {
+   "__class__": "Drift",
+   "length": 1.85
+  },
+  "sps_tpsgs": {
+   "__class__": "Drift",
+   "length": 1.853
+  },
+  "sps_tpst_3": {
+   "__class__": "Drift",
+   "length": 2.251
+  },
+  "sps_tqcd_001": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "sps_tqcd_003": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "sps_acfcah": {
+   "__class__": "CrabCavity",
+   "_model": 0,
+   "_integrator": 0
+  },
+  "sps_mdh": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "sps_mdha": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.306
+  },
+  "sps_mdhd": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.36
+  },
+  "sps_mdhw": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "sps_mdph": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "sps_mdsh": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.7
+  },
+  "sps_mkdha": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.6
+  },
+  "sps_mkdhb": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.6
+  },
+  "sps_mkel": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "sps_mkes": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "sps_mkpa": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.423
+  },
+  "sps_mkpc": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.78
+  },
+  "sps_mkp__03a": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.423
+  },
+  "sps_mkqh": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.96
+  },
+  "sps_mplh": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.06
+  },
+  "sps_mpnh": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.04
+  },
+  "sps_mpsh": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.714
+  },
+  "sps_mse": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "sps_mst": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "sps_zkha": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.0
+  },
+  "sps_zs___001": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.13
+  },
+  "sps_zs___003": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.13
+  },
+  "sps_aerb": {
+   "__class__": "Drift",
+   "length": 0.685
+  },
+  "sps_bdh": {
+   "__class__": "Drift",
+   "length": 2.32
+  },
+  "sps_bph": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "sps_bpsh": {
+   "__class__": "Drift",
+   "length": 3.38
+  },
+  "sps_aeg": {
+   "__class__": "Drift",
+   "length": 0.5593
+  },
+  "sps_aep": {
+   "__class__": "Drift",
+   "length": 1.0
+  },
+  "sps_aepa": {
+   "__class__": "Drift",
+   "length": 0.722
+  },
+  "sps_aepc": {
+   "__class__": "Drift",
+   "length": 0.722
+  },
+  "sps_aesa": {
+   "__class__": "Drift",
+   "length": 0.2305
+  },
+  "sps_aeta": {
+   "__class__": "Drift",
+   "length": 0.21
+  },
+  "sps_aew": {
+   "__class__": "Drift",
+   "length": 0.5105
+  },
+  "sps_aewa": {
+   "__class__": "Drift",
+   "length": 0.5105
+  },
+  "sps_aewb": {
+   "__class__": "Drift",
+   "length": 0.5661
+  },
+  "sps_apwl": {
+   "__class__": "Drift",
+   "length": 0.776
+  },
+  "sps_bbsr": {
+   "__class__": "Drift",
+   "length": 0.41
+  },
+  "sps_bctdc086": {
+   "__class__": "Drift",
+   "length": 0.694
+  },
+  "sps_bctdc108": {
+   "__class__": "Drift",
+   "length": 1.08
+  },
+  "sps_bctfr": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "sps_bctfs003": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "sps_bctfs021": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "sps_bctfs022": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "sps_bctw": {
+   "__class__": "Drift",
+   "length": 0.352
+  },
+  "sps_bct__086": {
+   "__class__": "Drift",
+   "length": 0.694
+  },
+  "sps_brsf": {
+   "__class__": "Drift"
+  },
+  "sps_bsmh": {
+   "__class__": "Drift",
+   "length": 0.61
+  },
+  "sps_bsrta": {
+   "__class__": "Drift",
+   "length": 0.244
+  },
+  "sps_btv": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "sps_btvel": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_btves": {
+   "__class__": "Drift",
+   "length": 0.33
+  },
+  "sps_btvs": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_btvt": {
+   "__class__": "Drift"
+  },
+  "sps_btv__003": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "sps_bwsa": {
+   "__class__": "Drift",
+   "length": 0.98
+  },
+  "sps_bwsd": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "sps_tcxhw": {
+   "__class__": "Drift",
+   "length": 0.54
+  },
+  "sps_teca": {
+   "__class__": "Drift",
+   "length": 0.352
+  },
+  "sps_tecs": {
+   "__class__": "Drift",
+   "length": 0.9
+  },
+  "sps_tecs_002": {
+   "__class__": "Drift",
+   "length": 0.226
+  },
+  "sps_vcbn": {
+   "__class__": "Drift",
+   "length": 2.774
+  },
+  "sps_vebw": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_vebx": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_veby": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_vetb": {
+   "__class__": "Drift",
+   "length": 0.7
+  },
+  "sps_vmzsa": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_vmzsb": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_vmzsc": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_vmzsd": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_vvfa": {
+   "__class__": "Drift",
+   "length": 0.334
+  },
+  "sps_vvfb": {
+   "__class__": "Drift",
+   "length": 0.37
+  },
+  "sps_vvsa": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "sps_vvsb": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "sps_vvse": {
+   "__class__": "Drift",
+   "length": 0.12
+  },
+  "sps_vvsf": {
+   "__class__": "Drift",
+   "length": 0.18
+  },
+  "sps_vvsl": {
+   "__class__": "Drift",
+   "length": 0.15
+  },
+  "sps_xcld": {
+   "__class__": "Drift",
+   "length": 10.272
+  },
+  "sps_xrphb": {
+   "__class__": "Drift",
+   "length": 0.417
+  },
+  "sps_xrp__002": {
+   "__class__": "Drift",
+   "length": 0.552
+  },
+  "omk": {
+   "__class__": "Marker"
+  },
+  "sps_bgiha": {
+   "__class__": "Drift"
+  },
+  "sps_bgiva": {
+   "__class__": "Drift"
+  },
+  "sps_bpce": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "sps_bpcl": {
+   "__class__": "Drift",
+   "length": 0.72
+  },
+  "sps_bpcn": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "sps_bpcr": {
+   "__class__": "Drift",
+   "length": 0.598
+  },
+  "sps_bpht": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "sps_bpmbh": {
+   "__class__": "Drift",
+   "length": 0.562
+  },
+  "sps_bpmbv": {
+   "__class__": "Drift",
+   "length": 0.562
+  },
+  "sps_bpmca": {
+   "__class__": "Drift"
+  },
+  "sps_bpmec": {
+   "__class__": "Drift",
+   "length": 0.285
+  },
+  "sps_brsc": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "sps_bwsrc": {
+   "__class__": "Drift",
+   "length": 0.52
+  },
+  "sps_lod": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "sps_loe": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "sps_loen": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.656,
+   "order": 5
+  },
+  "sps_lof": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "sps_lqsa": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.542,
+   "order": 5
+  },
+  "sps_qd": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 3.085,
+   "order": 5
+  },
+  "sps_qda": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 3.791,
+   "order": 5
+  },
+  "sps_qe": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "sps_qecd": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "sps_qf": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 3.085,
+   "order": 5
+  },
+  "sps_qfa": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 3.791,
+   "order": 5
+  },
+  "sps_qms": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "sps_mba": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0,
+   "h": 0.0,
+   "length": 6.26,
+   "k0_from_h": true,
+   "angle": 0.0,
+   "length_straight": 6.26
+  },
+  "sps_mbb": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0,
+   "h": 0.0,
+   "length": 6.26,
+   "k0_from_h": true,
+   "angle": 0.0,
+   "length_straight": 6.26
+  },
+  "sps_acl": {
+   "__class__": "Cavity",
+   "length": 3.52913,
+   "_model": 0,
+   "_integrator": 0
+  },
+  "sps_actcse": {
+   "__class__": "Cavity",
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0
+  },
+  "sps_actcsf": {
+   "__class__": "Cavity",
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0
+  },
+  "sps_actcsg": {
+   "__class__": "Cavity",
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0
+  },
+  "sps_actcsh": {
+   "__class__": "Cavity",
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0
+  },
+  "sps_actcsi": {
+   "__class__": "Cavity",
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0
+  },
+  "sps_actcsj": {
+   "__class__": "Cavity",
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0
+  },
+  "sps_lsd": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "sps_lse": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "sps_lsen": {
+   "__class__": "Sextupole",
+   "length": 0.72,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "sps_lsf": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "sps_adkcv": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.302
+  },
+  "sps_adksv": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.302
+  },
+  "sps_mdv": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "sps_mdva": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.424
+  },
+  "sps_mdvw": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "sps_mkdva": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.892
+  },
+  "sps_mkdvb": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.892
+  },
+  "sps_mkqv": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.416
+  },
+  "sps_mplv": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.555
+  },
+  "sps_mpsv": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "sps_zkv": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.002
+  },
+  "sps_bdv": {
+   "__class__": "Drift",
+   "length": 1.46
+  },
+  "sps_bpsv": {
+   "__class__": "Drift",
+   "length": 3.38
+  },
+  "sps_bpv": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "sps_bpvc": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "sps_bpw": {
+   "__class__": "Drift",
+   "length": 0.86
+  },
+  "sps_bpwa": {
+   "__class__": "Drift",
+   "length": 0.86
+  },
+  "sps_bpwb": {
+   "__class__": "Drift",
+   "length": 0.86
+  },
+  "sps_bpwc": {
+   "__class__": "Drift",
+   "length": 0.86
+  },
+  "begi.10010": {
+   "__class__": "Marker"
+  },
+  "qf.10010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.10030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.10103": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.10105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.10107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.10108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.10110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.10130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.10205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.10207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.10208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.10210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.10230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.10302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.10305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.10307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.10308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.10310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.10330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loe.10402": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "mdh.10407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.10408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.10410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.10430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.10507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.10508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.10510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.10530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.10602": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "mdh.10607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.10608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.10610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.10630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.10702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "vvsa.10705": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.10707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.10708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.10710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.10730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.10802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.10805": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.10807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.10808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.10810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.10830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.10907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.10908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.10910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.10930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.10950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.10990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.11007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.11008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.11010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.11030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.11050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.11070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.11090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.11105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.11107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.11108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.11110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.11130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.11150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.11170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.11190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.11205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.11207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.11208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.11210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.11230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.11250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.11270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.11290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.11303": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.11305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.11307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.11308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.11310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.11330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.11350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.11370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.11390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qe.11402": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "lsf.11405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.11407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.11408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.11410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "tidp.11434": {
+   "__class__": "Drift",
+   "length": 4.3
+  },
+  "mbb.11470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.11490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.11505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.11507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.11508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.11510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.11530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.11550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.11570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.11590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.11607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.11608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.11610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "qms.11631": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "qms.11632": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "qms.11634": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "qms.11635": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "bctfs.11640": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "vvsb.11652": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mkqh.11653": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.96
+  },
+  "vvsb.11656": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "btv.11656": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "tbsm.11672": {
+   "__class__": "Drift",
+   "length": 2.0
+  },
+  "vvsb.11678": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mkqv.11679": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.416
+  },
+  "vvsb.11692": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "vvsb.11699": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.11705": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.11706": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.11710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mdhw.11732": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "mdhw.11737": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "mdhw.11738": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "mdhw.11754": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "mdph.11757": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "mdph.11758": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "vvsb.11760": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "bshv.11771": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "bshv.11772": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "bshv.11773": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "tmasc.11802": {
+   "__class__": "Drift",
+   "length": 1.34
+  },
+  "qf.11810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mdh.11820": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.11831": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "vvsb.11832": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "bsmh.11859": {
+   "__class__": "Drift",
+   "length": 0.61
+  },
+  "btv.11860": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "tmasc.11897": {
+   "__class__": "Drift",
+   "length": 1.34
+  },
+  "vvsb.11903": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdva.11904": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.424
+  },
+  "bpce.11906": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "qda.11910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.009475375193310012,
+   "length": 3.791,
+   "order": 5
+  },
+  "mkpa.11931": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.423
+  },
+  "mkpa.11936": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.423
+  },
+  "mkpc.11952": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.78
+  },
+  "mkp.11955": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.423
+  },
+  "vvsb.11960": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdsh.11971": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.7
+  },
+  "btv.11973": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "btvs.11994": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "tbsj.11995": {
+   "__class__": "Drift",
+   "length": 2.1
+  },
+  "loe.12002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "lsf.12005": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.12007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.12008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.12010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.12030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.12107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.12108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.12110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.12130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpsh.12174": {
+   "__class__": "Drift",
+   "length": 3.38
+  },
+  "bpsv.12179": {
+   "__class__": "Drift",
+   "length": 3.38
+  },
+  "lof.12202": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.12207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.12208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.12210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.12230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.12301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.12305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.12307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpcn.12308": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "qd.12310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.12330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.12402": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "lsf.12405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.12407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.12408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.12410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.12430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.12505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.12507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpcn.12508": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "qd.12510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.12530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.12602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.12605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.12607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.12608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.12610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.12630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.12702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.12705": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.12707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.12708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.12710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.12730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.12802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.12807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.12808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.12810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.12830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lqsa.12902": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.542,
+   "order": 5
+  },
+  "mdv.12907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.12908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.12910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.12930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.12950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.12990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loen.13002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.656,
+   "order": 5
+  },
+  "mdh.13007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.13008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.13010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.13030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.13105": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.13107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.13108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.13110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.13130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.13205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.13207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.13208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.13210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.13230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.13302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "mdv.13307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.13308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.13310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.13330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.13407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.13408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.13410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.13430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.13502": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.13505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.13507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.13508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.13510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.13530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.13550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.13590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loe.13602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "lsf.13605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.13607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.13608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.20010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.20030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.20101": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.20105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.20107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.20108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.20110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.20130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bph.20203": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "lsf.20205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.20207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.20208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.20210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.20230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.20302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.20305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.20307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.20308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.20310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.20330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpht.20406": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "mdh.20407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.20408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.20410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.20430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.20504": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "bpv.20505": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "mdv.20507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.20508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.20510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.20530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.20602": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "mdh.20607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.20608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.20610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.20630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.20702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "bpvc.20705": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "mdv.20707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.20708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.20710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.20730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.20802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.20805": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.20807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.20808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.20810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.20830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpcn.20902": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "mdv.20907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.20908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.20910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.20930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.20950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.20990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bbsr.21001": {
+   "__class__": "Drift",
+   "length": 0.41
+  },
+  "btv.21003": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "mdh.21007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.21008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.21010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.21030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.21050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.21070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.21090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.21105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.21107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.21108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.21110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.21130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.21150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.21170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.21190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mpsh.21202": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.714
+  },
+  "lsf.21205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.21207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.21208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.21210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.21230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.21250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.21270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.21290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.21301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mpsv.21303": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "lsd.21305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.21307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.21308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.21310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.21330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.21350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.21370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.21390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpcr.21402": {
+   "__class__": "Drift",
+   "length": 0.598
+  },
+  "lsf.21405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.21407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.21408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.21410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mplh.21431": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.06
+  },
+  "bpcr.21434": {
+   "__class__": "Drift",
+   "length": 0.598
+  },
+  "bpcr.21436": {
+   "__class__": "Drift",
+   "length": 0.598
+  },
+  "bdh.21437": {
+   "__class__": "Drift",
+   "length": 2.32
+  },
+  "bdh.21451": {
+   "__class__": "Drift",
+   "length": 2.32
+  },
+  "bdv.21455": {
+   "__class__": "Drift",
+   "length": 1.46
+  },
+  "bpcr.21459": {
+   "__class__": "Drift",
+   "length": 0.598
+  },
+  "mbb.21470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.21490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mpsv.21503": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "lsd.21505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.21507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.21508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.21510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.21530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.21550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.21570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.21590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "tecs.21602": {
+   "__class__": "Drift",
+   "length": 0.226
+  },
+  "vvsb.21603": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "bpce.21604": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "mdha.21606": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.306
+  },
+  "qfa.21610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.00947394526091198,
+   "length": 3.791,
+   "order": 5
+  },
+  "vmzsa.21632": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "zs.21633": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.13
+  },
+  "vmzsb.21638": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "zs.21639": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.13
+  },
+  "vmzsc.21654": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "zs.21655": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.13
+  },
+  "vmzsc.21659": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "zs.21671": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.13
+  },
+  "vmzsc.21675": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "zs.21676": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 3.13
+  },
+  "vmzsd.21692": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "tce.21695": {
+   "__class__": "Drift",
+   "length": 2.7
+  },
+  "vvsb.21699": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "vvfa.21701": {
+   "__class__": "Drift",
+   "length": 0.334
+  },
+  "mdva.21703": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.424
+  },
+  "bpce.21706": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "qda.21710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.009475375193310012,
+   "length": 3.791,
+   "order": 5
+  },
+  "mpnh.21732": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.04
+  },
+  "tpst.21760": {
+   "__class__": "Drift",
+   "length": 2.251
+  },
+  "vebx.21773": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mst.21774": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.21778": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mst.21779": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.21793": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mst.21794": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebw.21798": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "vvse.21799": {
+   "__class__": "Drift",
+   "length": 0.12
+  },
+  "vvfb.21801": {
+   "__class__": "Drift",
+   "length": 0.37
+  },
+  "bpce.21803": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "mdha.21806": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.306
+  },
+  "qfa.21810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.00947394526091198,
+   "length": 3.791,
+   "order": 5
+  },
+  "vebw.21831": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.21832": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.21836": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.21837": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.21851": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.21852": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.21856": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.21857": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.21871": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.21872": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebw.21876": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "vvfb.21877": {
+   "__class__": "Drift",
+   "length": 0.37
+  },
+  "vvsf.21880": {
+   "__class__": "Drift",
+   "length": 0.18
+  },
+  "vvsb.21903": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "qda.21910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.009475375193310012,
+   "length": 3.791,
+   "order": 5
+  },
+  "bpce.21931": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "mdva.21932": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.424
+  },
+  "zkha.21991": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.0
+  },
+  "zkv.21993": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.002
+  },
+  "mplh.21995": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.06
+  },
+  "loe.22002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "lsf.22005": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.22007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.22008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.22010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.22030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mpsv.22103": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "mdv.22107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.22108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.22110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.22130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpcr.22172": {
+   "__class__": "Drift",
+   "length": 0.598
+  },
+  "bdv.22176": {
+   "__class__": "Drift",
+   "length": 1.46
+  },
+  "mplh.22195": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.06
+  },
+  "lof.22202": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.22207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.22208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.22210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.22230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.22301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mpsv.22303": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "lsd.22305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.22307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpcn.22308": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "qd.22310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.22330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.22402": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "lsf.22405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.22407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.22408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.22410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.22430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.22505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.22507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.22508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.22510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.22530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.22602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.22605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.22607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.22608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.22610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.22630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.22702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.22705": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.22707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpcn.22708": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "qd.22710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.22730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.22802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.22807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.22808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.22810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.22830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lqsa.22902": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.542,
+   "order": 5
+  },
+  "mdv.22907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.22908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.22910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.22930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.22950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.22990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loen.23002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.656,
+   "order": 5
+  },
+  "mdh.23007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.23008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.23010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.23030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.23105": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.23107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.23108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.23110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.23130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.23205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.23207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.23208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.23210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.23230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.23302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "mdv.23307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.23308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.23310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.23330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.23407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.23408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.23410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.23430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.23502": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.23505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.23507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.23508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.23510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.23530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.23550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.23590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loen.23602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.656,
+   "order": 5
+  },
+  "lsf.23605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.23607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.23608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.30010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.30030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.30103": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.30105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.30107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.30108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.30110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.30130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qe.30202": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "lsf.30205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.30207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.30208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.30210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.30230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.30305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.30307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.30308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.30310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.30330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.30407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.30408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.30410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.30430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.30507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.30508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.30510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.30530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qecd.30602": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "mdh.30607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.30608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.30610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.30630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.30702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "vvsa.30705": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.30707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.30708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.30710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.30730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.30802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.30805": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.30807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.30808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.30810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.30830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "aewa.30903": {
+   "__class__": "Drift",
+   "length": 0.5105
+  },
+  "mdv.30907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.30908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.30910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.30930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.30950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.30990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.31007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.31008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.31010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.31030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.31050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.31070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.31090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpwa.31101": {
+   "__class__": "Drift",
+   "length": 0.86
+  },
+  "lsd.31105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.31107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.31108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.31110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.31130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.31150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.31170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.31190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpcr.31202": {
+   "__class__": "Drift",
+   "length": 0.598
+  },
+  "lsf.31205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.31207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.31208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.31210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.31230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.31250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.31270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.31290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.31301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "aerb.31302": {
+   "__class__": "Drift",
+   "length": 0.685
+  },
+  "lsd.31305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.31307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.31308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.31310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.31330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.31350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.31370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.31390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qecd.31402": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "lsf.31405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.31407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.31408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.31410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "bctfr.31451": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "bpw.31456": {
+   "__class__": "Drift",
+   "length": 0.86
+  },
+  "bctdc.31458": {
+   "__class__": "Drift",
+   "length": 0.694
+  },
+  "mbb.31470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.31490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "aewb.31502": {
+   "__class__": "Drift",
+   "length": 0.5661
+  },
+  "lsd.31505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.31507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.31508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.31510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.31530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.31550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.31570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.31590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bph.31605": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "mdh.31607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.31608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.31610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "vvsb.31620": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "actcse.31632": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcse.31637": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcse.31654": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "vvsb.31671": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "actcsf.31672": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsf.31678": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsf.31695": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "vvsb.31706": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.31707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.31708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.31710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "aeta.31720": {
+   "__class__": "Drift",
+   "length": 0.21
+  },
+  "aew.31731": {
+   "__class__": "Drift",
+   "length": 0.5105
+  },
+  "apwl.31731": {
+   "__class__": "Drift",
+   "length": 0.776
+  },
+  "aewa.31733": {
+   "__class__": "Drift",
+   "length": 0.5105
+  },
+  "aeg.31733": {
+   "__class__": "Drift",
+   "length": 0.5593
+  },
+  "acl.31735": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 3.52913,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 801058000.0,
+   "voltage": 250000.0
+  },
+  "vvsb.31740": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "actcsg.31751": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsg.31758": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsg.31774": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsg.31780": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "vvsb.31797": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "aep.31799": {
+   "__class__": "Drift",
+   "length": 1.0
+  },
+  "aepc.31801": {
+   "__class__": "Drift",
+   "length": 0.722
+  },
+  "aepa.31804": {
+   "__class__": "Drift",
+   "length": 0.722
+  },
+  "mdh.31807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.31808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qspl.31809": {
+   "__class__": "Marker"
+  },
+  "qf.31810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "vvsb.31820": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "actcsh.31832": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsh.31838": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsh.31854": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "vvsb.31871": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "actcsi.31872": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsi.31878": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsi.31895": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "vvsb.31906": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.31907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.31908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.31910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "bctw.31931": {
+   "__class__": "Drift",
+   "length": 0.352
+  },
+  "aesa.31931": {
+   "__class__": "Drift",
+   "length": 0.2305
+  },
+  "bpwc.31933": {
+   "__class__": "Drift",
+   "length": 0.86
+  },
+  "acl.31936": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 3.52913,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 801058000.0,
+   "voltage": 250000.0
+  },
+  "vvsb.31951": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "actcsj.31952": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsj.31958": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsj.31974": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "actcsj.31991": {
+   "__class__": "Cavity",
+   "lag": 180.0,
+   "length": 4.114,
+   "_model": 0,
+   "_integrator": 0,
+   "frequency": 200264500.0,
+   "voltage": 225000.0
+  },
+  "vvsb.31997": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "loe.32002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "lsf.32005": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.32007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.32008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.32010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.32030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpwb.32101": {
+   "__class__": "Drift",
+   "length": 0.86
+  },
+  "mdv.32107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.32108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.32110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.32130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "adkcv.32171": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.302
+  },
+  "adkcv.32172": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.302
+  },
+  "adksv.32173": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.302
+  },
+  "lof.32202": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.32207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.32208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.32210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.32230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.32303": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.32305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.32307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpcn.32308": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "qd.32310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.32330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.32402": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "lsf.32405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.32407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.32408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.32410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.32430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.32505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.32507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.32508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.32510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.32530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.32602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.32605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.32607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.32608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.32610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.32630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.32702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.32705": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.32707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpcn.32708": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "qd.32710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.32730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.32802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.32807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.32808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.32810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.32830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lqsa.32902": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.542,
+   "order": 5
+  },
+  "mdv.32907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.32908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.32910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.32930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.32950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.32990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loe.33002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "mdh.33007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.33008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.33010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.33030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.33105": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.33107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.33108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.33110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.33130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.33205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.33207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.33208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.33210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.33230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.33302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "mdv.33307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.33308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.33310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.33330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "aepa.33404": {
+   "__class__": "Drift",
+   "length": 0.722
+  },
+  "mdh.33407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.33408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.33410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.33430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.33502": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.33505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.33507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.33508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.33510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.33530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.33550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.33590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loe.33602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "lsf.33605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.33607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.33608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.40010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.40030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.40103": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.40105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.40107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.40108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.40110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.40130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.40205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.40207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.40208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.40210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.40230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.40302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.40305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.40307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.40308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.40310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.40330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loe.40402": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "mdh.40407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.40408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.40410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.40430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.40507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.40508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.40510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.40530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.40602": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "mdh.40607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.40608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.40610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.40630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.40702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "vvsa.40705": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.40707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.40708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.40710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.40730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.40802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.40805": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.40807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.40808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.40810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.40830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.40907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.40908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.40910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.40930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.40950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.40990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.41007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.41008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.41010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.41030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.41050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.41070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.41090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.41105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.41107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.41108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.41110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.41130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.41150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.41170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.41190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.41205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.41207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.41208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.41210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.41230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.41250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.41270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.41290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.41301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mpsv.41303": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "lsd.41305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.41307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.41308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.41310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.41330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.41350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.41370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.41390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mpsh.41402": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.714
+  },
+  "lsf.41405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.41407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.41408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.41410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "bwsa.41420": {
+   "__class__": "Drift",
+   "length": 0.98
+  },
+  "bctdc.41435": {
+   "__class__": "Drift",
+   "length": 0.694
+  },
+  "bctfs.41438": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "mbb.41470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.41490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mplv.41501": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.555
+  },
+  "lsd.41505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.41507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.41508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.41510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.41530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.41550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.41570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.41590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.41607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.41607": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.41610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "vvsb.41620": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mke.41631": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "mke.41634": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "mke.41637": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "mke.41651": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "vvsb.41658": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mplh.41658": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.06
+  },
+  "bwsrc.41677": {
+   "__class__": "Drift",
+   "length": 0.52
+  },
+  "bwsrc.41678": {
+   "__class__": "Drift",
+   "length": 0.52
+  },
+  "vvfa.41698": {
+   "__class__": "Drift",
+   "length": 0.334
+  },
+  "mdva.41703": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.424
+  },
+  "bpce.41705": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "qda.41710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.009475375193310012,
+   "length": 3.791,
+   "order": 5
+  },
+  "vvsb.41731": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "xcld.41737": {
+   "__class__": "Drift",
+   "length": 10.272
+  },
+  "vvsb.41757": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "teca.41777": {
+   "__class__": "Drift",
+   "length": 0.352
+  },
+  "vvsb.41779": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "btvt.41797": {
+   "__class__": "Drift"
+  },
+  "tpsc4j.41797": {
+   "__class__": "Drift",
+   "length": 1.3605
+  },
+  "bpce.41801": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "mdha.41804": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.306
+  },
+  "qfa.41810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.00947394526091198,
+   "length": 3.791,
+   "order": 5
+  },
+  "btve.41831": {
+   "__class__": "Drift",
+   "length": 0.33
+  },
+  "tpsg.41832": {
+   "__class__": "Drift",
+   "length": 3.098
+  },
+  "mse.41837": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "veby.41851": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.41852": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "veby.41855": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.41856": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "mse.41871": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "mse.41876": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "mse.41891": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "btve.41895": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "vvsb.41904": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "qda.41910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.009475375193310012,
+   "length": 3.791,
+   "order": 5
+  },
+  "bpce.41931": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "mdva.41932": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.424
+  },
+  "mplh.41994": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.06
+  },
+  "lsf.42005": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.42007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.42008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.42010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.42030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mplv.42101": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.555
+  },
+  "bpmec.42105": {
+   "__class__": "Drift",
+   "length": 0.285
+  },
+  "mdv.42107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.42108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.42110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.42130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpcl.42171": {
+   "__class__": "Drift",
+   "length": 0.72
+  },
+  "mpsh.42198": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.714
+  },
+  "lof.42202": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.42207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.42208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.42210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.42230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.42301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mpsv.42303": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "lsd.42305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.42307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.42308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.42310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.42330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsen.42402": {
+   "__class__": "Sextupole",
+   "length": 0.72,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "lsf.42405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.42407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.42408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.42410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.42430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.42505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.42507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.42508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.42510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.42530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.42602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.42605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.42607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.42608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.42610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.42630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.42702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.42705": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.42707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.42708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.42710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.42730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.42802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.42807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.42808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.42810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.42830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lqsa.42902": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.542,
+   "order": 5
+  },
+  "mdv.42907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.42908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.42910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.42930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.42950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.42990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.43007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.43008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.43010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.43030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.43101": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.43107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.43108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.43110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.43130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.43205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.43207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.43208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.43210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.43230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.43302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "mdv.43307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.43308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.43310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.43330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.43407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.43408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.43410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.43430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.43502": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.43505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.43507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.43508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.43510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.43530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.43550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.43590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.43605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.43607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.43608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.50010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.50030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.50101": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.50105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.50107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.50108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.50110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.50130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qe.50202": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "lsf.50205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.50207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.50208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.50210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.50230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.50302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.50305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.50307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.50308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.50310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.50330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loen.50402": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.656,
+   "order": 5
+  },
+  "mdh.50407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.50408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.50410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.50430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.50507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.50508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.50510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.50530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.50602": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "mdh.50607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.50608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.50610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.50630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.50702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "vvsa.50705": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.50707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.50708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.50710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.50730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.50802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.50805": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.50807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.50808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.50810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.50830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.50907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.50908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.50910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.50930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.50950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.50990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.51007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.51008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.51010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.51030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.51050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.51070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.51090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.51105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.51107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.51108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.51110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.51130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.51150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.51170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.51190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.51205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.51207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.51208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.51210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.51230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.51250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.51270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.51290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.51301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "bpmbv.51303": {
+   "__class__": "Drift",
+   "length": 0.562
+  },
+  "lsd.51305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.51307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.51308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.51310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.51330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.51350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.51370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.51390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qe.51402": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "lsf.51405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.51407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.51408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.51410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "bctdc.51454": {
+   "__class__": "Drift",
+   "length": 1.08
+  },
+  "bctdc.51456": {
+   "__class__": "Drift",
+   "length": 1.08
+  },
+  "bctfs.51458": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "mbb.51470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.51490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpmbv.51503": {
+   "__class__": "Drift",
+   "length": 0.562
+  },
+  "lsd.51505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.51507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.51508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.51510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.51530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.51550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.51570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.51590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bpce.51604": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "mdha.51606": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.306
+  },
+  "qfa.51610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.00947394526091198,
+   "length": 3.791,
+   "order": 5
+  },
+  "bsrta.51631": {
+   "__class__": "Drift",
+   "length": 0.244
+  },
+  "mdhw.51632": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "bgiha.51634": {
+   "__class__": "Drift"
+  },
+  "mdhw.51634": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "mdhw.51637": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "bwsrc.51637": {
+   "__class__": "Drift",
+   "length": 0.52
+  },
+  "bwsrc.51638": {
+   "__class__": "Drift",
+   "length": 0.52
+  },
+  "bwsd.51639": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "tcxhw.51651": {
+   "__class__": "Drift",
+   "length": 0.54
+  },
+  "tecs.51652": {
+   "__class__": "Drift",
+   "length": 0.9
+  },
+  "mdvw.51672": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "bgiva.51674": {
+   "__class__": "Drift"
+  },
+  "mdvw.51674": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "mdvw.51677": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 0,
+   "length": 0.548
+  },
+  "vvsa.51678": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "vvsa.51697": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mkdvb.51698": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.892
+  },
+  "mdv.51707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.51708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.51710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mkdva.51731": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.892
+  },
+  "mkdvb.51735": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.892
+  },
+  "vvsb.51740": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mkdha.51751": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.6
+  },
+  "mkdha.51754": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.6
+  },
+  "mkdhb.51757": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 1.6
+  },
+  "vvsb.51759": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "xrp.51779": {
+   "__class__": "Drift",
+   "length": 0.552
+  },
+  "xrp.51791": {
+   "__class__": "Drift",
+   "length": 0.552
+  },
+  "bshv.51793": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "tcpc.51794": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "tqcd.51795": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "tacw.51797": {
+   "__class__": "Drift",
+   "length": 0.852
+  },
+  "tecs.51799": {
+   "__class__": "Drift",
+   "length": 0.9
+  },
+  "qfa.51810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.00947394526091198,
+   "length": 3.791,
+   "order": 5
+  },
+  "mdhd.51832": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.36
+  },
+  "bpce.51833": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "btv.51858": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "vvsl.51859": {
+   "__class__": "Drift",
+   "length": 0.15
+  },
+  "tidvg.51872": {
+   "__class__": "Drift",
+   "length": 5.0
+  },
+  "tmadi.51896": {
+   "__class__": "Drift",
+   "length": 1.34
+  },
+  "vvsa.51898": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "tmadi.51901": {
+   "__class__": "Drift",
+   "length": 1.34
+  },
+  "qd.51910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mdv.51920": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.51931": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "tcsm.51932": {
+   "__class__": "Drift",
+   "length": 1.83
+  },
+  "xrp.51991": {
+   "__class__": "Drift",
+   "length": 0.552
+  },
+  "xrp.51993": {
+   "__class__": "Drift",
+   "length": 0.552
+  },
+  "tqcd.51997": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "tacw.51998": {
+   "__class__": "Drift",
+   "length": 0.848
+  },
+  "bpmbh.51999": {
+   "__class__": "Drift",
+   "length": 0.562
+  },
+  "loen.52002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.656,
+   "order": 5
+  },
+  "lsf.52005": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.52007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.52008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.52010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.52030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdv.52107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.52108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.52110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.52130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "brsf.52140": {
+   "__class__": "Drift"
+  },
+  "mbb.52150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bwsd.52171": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "brsc.52191": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "tal.52196": {
+   "__class__": "Drift",
+   "length": 1.25
+  },
+  "xrph.52202": {
+   "__class__": "Drift",
+   "length": 0.417
+  },
+  "mdh.52207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.52208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.52210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.52230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.52301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.52305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.52307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.52308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.52310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.52330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.52402": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "lsf.52405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.52407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.52408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.52410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.52430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.52505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.52507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.52508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.52510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.52530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.52602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.52605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.52607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.52608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.52610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.52630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.52702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.52705": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.52707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.52708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.52710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.52730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.52802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.52807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.52808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.52810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.52830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lqsa.52902": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.542,
+   "order": 5
+  },
+  "mdv.52907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.52908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.52910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.52930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.52950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.52990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.53002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.53007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.53008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.53010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.53030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.53105": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.53107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.53108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.53110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.53130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.53205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.53207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.53208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.53210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.53230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.53302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "mdv.53307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.53308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.53310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.53330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qecd.53402": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "mdh.53407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.53408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.53410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.53430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.53502": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.53505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.53507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.53508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.53510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.53530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.53550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.53590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loen.53602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.656,
+   "order": 5
+  },
+  "lsf.53605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.53607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.53608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.60010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.60030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.60103": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "lsd.60105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.60107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.60108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.60110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.60130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.60205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.60207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.60208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.60210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.60230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qe.60302": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "lsd.60305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.60307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.60308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.60310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.60330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qe.60402": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "mdh.60407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.60408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.60410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.60430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qe.60502": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "mdv.60507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.60508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.60510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.60530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "qe.60602": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.698,
+   "order": 5
+  },
+  "mdh.60607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.60608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.60610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.60630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.60702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "vvsa.60705": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.60707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.60708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.60710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.60730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.60802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.60805": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.60807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.60808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.60810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.60830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bctfs.60903": {
+   "__class__": "Drift",
+   "length": 0.222
+  },
+  "mdv.60907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.60908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.60910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.60930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.60950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.60990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "bbsr.61001": {
+   "__class__": "Drift",
+   "length": 0.41
+  },
+  "btv.61003": {
+   "__class__": "Drift",
+   "length": 0.45
+  },
+  "mdh.61007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.61008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.61010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.61030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.61050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.61070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.61090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.61105": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.61107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpcn.61108": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "qd.61110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.61130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.61150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.61170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.61190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.61205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.61207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.61208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.61210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.61230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.61250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.61270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.61290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.61301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mpsv.61303": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "lsd.61305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.61307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpcn.61308": {
+   "__class__": "Drift",
+   "length": 0.236
+  },
+  "qd.61310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.61330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.61350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.61370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.61390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mpsh.61402": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.714
+  },
+  "lsf.61405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.61407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.61408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.61410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "vvfa.61459": {
+   "__class__": "Drift",
+   "length": 0.334
+  },
+  "mbb.61470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.61490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mpsv.61503": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "lsd.61505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.61507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.61508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.61510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.61530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.61550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.61570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.61590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.61607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.61608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.61610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "vvsb.61620": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mke.61631": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "mke.61634": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "mke.61637": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.014
+  },
+  "vvsb.61654": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mplh.61655": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.06
+  },
+  "vvfa.61695": {
+   "__class__": "Drift",
+   "length": 0.334
+  },
+  "mdva.61703": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.424
+  },
+  "bpce.61705": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "qda.61710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.009475375193310012,
+   "length": 3.791,
+   "order": 5
+  },
+  "vvsb.61731": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "vcbn.61732": {
+   "__class__": "Drift",
+   "length": 2.774
+  },
+  "bpmca.61736": {
+   "__class__": "Drift"
+  },
+  "acfcah.61738": {
+   "__class__": "CrabCavity",
+   "_model": 0,
+   "_integrator": 0
+  },
+  "acfcah.61739": {
+   "__class__": "CrabCavity",
+   "_model": 0,
+   "_integrator": 0
+  },
+  "vcbn.61752": {
+   "__class__": "Drift",
+   "length": 2.774
+  },
+  "vvsb.61757": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "btve.61759": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "tpsg.61760": {
+   "__class__": "Drift",
+   "length": 1.85
+  },
+  "tpsg.61773": {
+   "__class__": "Drift",
+   "length": 1.853
+  },
+  "tpsg.61776": {
+   "__class__": "Drift",
+   "length": 1.853
+  },
+  "mst.61779": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.61793": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mst.61794": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "btve.61798": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "vvse.61799": {
+   "__class__": "Drift",
+   "length": 0.12
+  },
+  "vvfb.61801": {
+   "__class__": "Drift",
+   "length": 0.37
+  },
+  "bpce.61804": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "mdha.61805": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.306
+  },
+  "qspl.61809": {
+   "__class__": "Marker"
+  },
+  "qfa.61810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.00947394526091198,
+   "length": 3.791,
+   "order": 5
+  },
+  "btve.61831": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.61832": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.61836": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.61837": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.61851": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.61852": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.61856": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.61857": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "vebx.61871": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "mse.61872": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.38
+  },
+  "btve.61876": {
+   "__class__": "Drift",
+   "length": 0.53
+  },
+  "vetb.61876": {
+   "__class__": "Drift",
+   "length": 0.7
+  },
+  "vvfb.61877": {
+   "__class__": "Drift",
+   "length": 0.37
+  },
+  "vvsf.61880": {
+   "__class__": "Drift",
+   "length": 0.18
+  },
+  "vvsb.61903": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "qda.61910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.009475375193310012,
+   "length": 3.791,
+   "order": 5
+  },
+  "bpce.61931": {
+   "__class__": "Drift",
+   "length": 0.4
+  },
+  "mdva.61932": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.424
+  },
+  "vvfa.61957": {
+   "__class__": "Drift",
+   "length": 0.334
+  },
+  "mplh.61996": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 2.06
+  },
+  "lsf.62005": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.62007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.62008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.62010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.62030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mpsv.62103": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "mdv.62107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.62108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.62110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.62130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mpsh.62199": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.714
+  },
+  "lof.62202": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.62207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.62208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.62210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.62230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.62301": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mpsv.62303": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.275
+  },
+  "lsd.62305": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.62307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.62308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.62310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.62330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lse.62402": {
+   "__class__": "Sextupole",
+   "length": 0.74,
+   "_model": 0,
+   "_integrator": 0,
+   "order": 5
+  },
+  "lsf.62405": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.62407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.62408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.62410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.62430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsd.62505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.10791912465451854,
+   "order": 5
+  },
+  "mdv.62507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.62508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.62510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.62530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.62602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "lsf.62605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.06464580696074636,
+   "order": 5
+  },
+  "mdh.62607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.62608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.62610": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.62630": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62650": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62670": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62690": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.62702": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.62705": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.62707": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.62708": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.62710": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.62730": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62750": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62770": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62790": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lof.62802": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.705,
+   "order": 5
+  },
+  "mdh.62807": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.62808": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.62810": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.62830": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62850": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62870": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62890": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lqsa.62902": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.542,
+   "order": 5
+  },
+  "mdv.62907": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.62908": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.62910": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.62930": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.62950": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62970": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.62990": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loe.63002": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "mdh.63007": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.63008": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.63010": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.63030": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63050": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63070": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63090": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "vvsa.63105": {
+   "__class__": "Drift",
+   "length": 0.175
+  },
+  "mdv.63107": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.63108": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.63110": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.63130": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63150": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63170": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63190": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lsf.63205": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.63207": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.63208": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.63210": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.63230": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63250": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63270": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63290": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.63302": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "mdv.63307": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.63308": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.63310": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.63330": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63350": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63370": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63390": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mdh.63407": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.63408": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qf.63410": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": 0.01157926643000353,
+   "length": 3.085,
+   "order": 5
+  },
+  "mba.63430": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63450": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63470": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63490": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "lod.63502": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.677,
+   "order": 5
+  },
+  "lsd.63505": {
+   "__class__": "Sextupole",
+   "length": 0.426,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": -0.05989435299384773,
+   "order": 5
+  },
+  "mdv.63507": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bpv.63508": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "qd.63510": {
+   "__class__": "Quadrupole",
+   "_model": 0,
+   "_integrator": 0,
+   "k1": -0.01158101412515668,
+   "length": 3.085,
+   "order": 5
+  },
+  "mbb.63530": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mbb.63550": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63570": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "mba.63590": {
+   "__class__": "RBend",
+   "_rbend_model": 0,
+   "_edge_exit_model": 0,
+   "_integrator": 0,
+   "_edge_entry_model": 0,
+   "order": 5,
+   "model": "adaptive",
+   "k0": 0.0013490601351007177,
+   "h": 0.0013490601351007177,
+   "length": 6.260018602780449,
+   "k0_from_h": true,
+   "angle": 0.008445141542,
+   "length_straight": 6.26
+  },
+  "loe.63602": {
+   "__class__": "Octupole",
+   "_model": 0,
+   "_integrator": 0,
+   "length": 0.74,
+   "order": 5
+  },
+  "lsf.63605": {
+   "__class__": "Sextupole",
+   "length": 0.435,
+   "_model": 0,
+   "_integrator": 0,
+   "k2": 0.04982277106309112,
+   "order": 5
+  },
+  "mdh.63607": {
+   "__class__": "Multipole",
+   "_model": 0,
+   "_integrator": 0,
+   "_isthick": 1,
+   "length": 0.25
+  },
+  "bph.63608": {
+   "__class__": "Drift",
+   "length": 0.275
+  },
+  "end.10010": {
+   "__class__": "Marker"
+  },
+  "drift_1": {
+   "__class__": "Drift",
+   "length": 0.36001003900000095
+  },
+  "drift_2": {
+   "__class__": "Drift",
+   "length": 0.40001934000000183
+  },
+  "drift_3": {
+   "__class__": "Drift",
+   "length": 0.39001934000000205
+  },
+  "drift_4": {
+   "__class__": "Drift",
+   "length": 0.38001933999999693
+  },
+  "drift_5": {
+   "__class__": "Drift",
+   "length": 0.4943093010000048
+  },
+  "drift_6": {
+   "__class__": "Drift",
+   "length": 0.4633999999999965
+  },
+  "drift_7": {
+   "__class__": "Drift",
+   "length": 0.1490000000000009
+  },
+  "drift_8": {
+   "__class__": "Drift",
+   "length": 0.015000000000000568
+  },
+  "drift_9": {
+   "__class__": "Drift",
+   "length": 0.09499999999999886
+  },
+  "drift_10": {
+   "__class__": "Drift",
+   "length": 0.3500100390000114
+  },
+  "drift_11": {
+   "__class__": "Drift",
+   "length": 0.38001933999999693
+  },
+  "drift_12": {
+   "__class__": "Drift",
+   "length": 0.39001934000000205
+  },
+  "drift_13": {
+   "__class__": "Drift",
+   "length": 0.40001934000000716
+  },
+  "drift_14": {
+   "__class__": "Drift",
+   "length": 1.1382093009999963
+  },
+  "drift_15": {
+   "__class__": "Drift",
+   "length": 0.13449999999999562
+  },
+  "drift_16": {
+   "__class__": "Drift",
+   "length": 0.02499999999999858
+  },
+  "drift_17": {
+   "__class__": "Drift",
+   "length": 0.09500000000000597
+  },
+  "drift_18": {
+   "__class__": "Drift",
+   "length": 0.3600100390000023
+  },
+  "drift_19": {
+   "__class__": "Drift",
+   "length": 0.40001933999998585
+  },
+  "drift_20": {
+   "__class__": "Drift",
+   "length": 0.39001933999999494
+  },
+  "drift_21": {
+   "__class__": "Drift",
+   "length": 0.38001934000000404
+  },
+  "drift_22": {
+   "__class__": "Drift",
+   "length": 0.2985093009999815
+  },
+  "drift_23": {
+   "__class__": "Drift",
+   "length": 0.15720000000000312
+  },
+  "drift_24": {
+   "__class__": "Drift",
+   "length": 0.1489999999999867
+  },
+  "drift_25": {
+   "__class__": "Drift",
+   "length": 0.015000000000000568
+  },
+  "drift_26": {
+   "__class__": "Drift",
+   "length": 0.09500000000001307
+  },
+  "drift_27": {
+   "__class__": "Drift",
+   "length": 0.35001003899999716
+  },
+  "drift_28": {
+   "__class__": "Drift",
+   "length": 0.3800193399999756
+  },
+  "drift_29": {
+   "__class__": "Drift",
+   "length": 0.39001933999999494
+  },
+  "drift_30": {
+   "__class__": "Drift",
+   "length": 0.40001934000001427
+  },
+  "drift_31": {
+   "__class__": "Drift",
+   "length": 0.31900930099997993
+  },
+  "drift_32": {
+   "__class__": "Drift",
+   "length": 0.6487000000000194
+  },
+  "drift_33": {
+   "__class__": "Drift",
+   "length": 0.024999999999991473
+  },
+  "drift_34": {
+   "__class__": "Drift",
+   "length": 0.09499999999999886
+  },
+  "drift_35": {
+   "__class__": "Drift",
+   "length": 0.3600100390000307
+  },
+  "drift_36": {
+   "__class__": "Drift",
+   "length": 0.40001934000000006
+  },
+  "drift_37": {
+   "__class__": "Drift",
+   "length": 0.39001934000000915
+  },
+  "drift_38": {
+   "__class__": "Drift",
+   "length": 0.38001934000001825
+  },
+  "drift_39": {
+   "__class__": "Drift",
+   "length": 1.7077093009999942
+  },
+  "drift_40": {
+   "__class__": "Drift",
+   "length": 0.014999999999986358
+  },
+  "drift_41": {
+   "__class__": "Drift",
+   "length": 0.09499999999999886
+  },
+  "drift_42": {
+   "__class__": "Drift",
+   "length": 0.3500100390000114
+  },
+  "drift_43": {
+   "__class__": "Drift",
+   "length": 0.38001934000001825
+  },
+  "drift_44": {
+   "__class__": "Drift",
+   "length": 0.39001934000000915
+  },
+  "drift_45": {
+   "__class__": "Drift",
+   "length": 0.40001934000000006
+  },
+  "drift_46": {
+   "__class__": "Drift",
+   "length": 0.310009301000008
+  },
+  "drift_47": {
+   "__class__": "Drift",
+   "length": 0.6576999999999771
+  },
+  "drift_48": {
+   "__class__": "Drift",
+   "length": 0.024999999999977263
+  },
+  "drift_49": {
+   "__class__": "Drift",
+   "length": 0.09499999999999886
+  },
+  "drift_50": {
+   "__class__": "Drift",
+   "length": 0.3600100390000307
+  },
+  "drift_51": {
+   "__class__": "Drift",
+   "length": 0.40001934000000006
+  },
+  "drift_52": {
+   "__class__": "Drift",
+   "length": 0.39001934000000915
+  },
+  "drift_53": {
+   "__class__": "Drift",
+   "length": 0.38001934000001825
+  },
+  "drift_54": {
+   "__class__": "Drift",
+   "length": 0.29850930100002415
+  },
+  "drift_55": {
+   "__class__": "Drift",
+   "length": 0.0801999999999623
+  },
+  "drift_56": {
+   "__class__": "Drift",
+   "length": 0.47700000000000387
+  },
+  "drift_57": {
+   "__class__": "Drift",
+   "length": 0.01500000000001478
+  },
+  "drift_58": {
+   "__class__": "Drift",
+   "length": 0.09499999999999886
+  },
+  "drift_59": {
+   "__class__": "Drift",
+   "length": 0.35001003899998295
+  },
+  "drift_60": {
+   "__class__": "Drift",
+   "length": 0.38001934000001825
+  },
+  "drift_61": {
+   "__class__": "Drift",
+   "length": 0.39001934000000915
+  },
+  "drift_62": {
+   "__class__": "Drift",
+   "length": 0.40001934000000006
+  },
+  "drift_63": {
+   "__class__": "Drift",
+   "length": 0.29450930100000505
+  },
+  "drift_64": {
+   "__class__": "Drift",
+   "length": 0.13869999999997162
+  },
+  "drift_65": {
+   "__class__": "Drift",
+   "length": 0.13450000000000273
+  },
+  "drift_66": {
+   "__class__": "Drift",
+   "length": 0.025000000000005684
+  },
+  "drift_67": {
+   "__class__": "Drift",
+   "length": 0.09499999999999886
+  },
+  "drift_68": {
+   "__class__": "Drift",
+   "length": 0.36001003899997386
+  },
+  "drift_69": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_70": {
+   "__class__": "Drift",
+   "length": 0.3900193400000376
+  },
+  "drift_71": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_72": {
+   "__class__": "Drift",
+   "length": 1.7077093010000226
+  },
+  "drift_73": {
+   "__class__": "Drift",
+   "length": 0.014999999999986358
+  },
+  "drift_74": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_75": {
+   "__class__": "Drift",
+   "length": 0.3500100390000398
+  },
+  "drift_76": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_77": {
+   "__class__": "Drift",
+   "length": 0.3900193400000376
+  },
+  "drift_78": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_79": {
+   "__class__": "Drift",
+   "length": 1.7077093010000226
+  },
+  "drift_80": {
+   "__class__": "Drift",
+   "length": 0.025000000000034106
+  },
+  "drift_81": {
+   "__class__": "Drift",
+   "length": 0.09499999999997044
+  },
+  "drift_82": {
+   "__class__": "Drift",
+   "length": 0.3600100390000307
+  },
+  "drift_83": {
+   "__class__": "Drift",
+   "length": 0.4000193400000285
+  },
+  "drift_84": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_85": {
+   "__class__": "Drift",
+   "length": 0.38001934000004667
+  },
+  "drift_86": {
+   "__class__": "Drift",
+   "length": 1.132709301000034
+  },
+  "drift_87": {
+   "__class__": "Drift",
+   "length": 0.14899999999994407
+  },
+  "drift_88": {
+   "__class__": "Drift",
+   "length": 0.015000000000043201
+  },
+  "drift_89": {
+   "__class__": "Drift",
+   "length": 0.09499999999997044
+  },
+  "drift_90": {
+   "__class__": "Drift",
+   "length": 0.3500100390000398
+  },
+  "drift_91": {
+   "__class__": "Drift",
+   "length": 0.38001934000004667
+  },
+  "drift_92": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_93": {
+   "__class__": "Drift",
+   "length": 0.4000193400000285
+  },
+  "drift_94": {
+   "__class__": "Drift",
+   "length": 1.1382093010000176
+  },
+  "drift_95": {
+   "__class__": "Drift",
+   "length": 0.13450000000000273
+  },
+  "drift_96": {
+   "__class__": "Drift",
+   "length": 0.024999999999977263
+  },
+  "drift_97": {
+   "__class__": "Drift",
+   "length": 0.09500000000008413
+  },
+  "drift_98": {
+   "__class__": "Drift",
+   "length": 0.36001003899997386
+  },
+  "drift_99": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_100": {
+   "__class__": "Drift",
+   "length": 0.3900193400000376
+  },
+  "drift_101": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_102": {
+   "__class__": "Drift",
+   "length": 0.49430930099998704
+  },
+  "drift_103": {
+   "__class__": "Drift",
+   "length": 0.46340000000003556
+  },
+  "drift_104": {
+   "__class__": "Drift",
+   "length": 0.1490000000000009
+  },
+  "drift_105": {
+   "__class__": "Drift",
+   "length": 0.014999999999986358
+  },
+  "drift_106": {
+   "__class__": "Drift",
+   "length": 0.09500000000008413
+  },
+  "drift_107": {
+   "__class__": "Drift",
+   "length": 0.35001003899998295
+  },
+  "drift_108": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_109": {
+   "__class__": "Drift",
+   "length": 0.3900193400000376
+  },
+  "drift_110": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_111": {
+   "__class__": "Drift",
+   "length": 0.3090093010000601
+  },
+  "drift_112": {
+   "__class__": "Drift",
+   "length": 0.13119999999997844
+  },
+  "drift_113": {
+   "__class__": "Drift",
+   "length": 0.13450000000000273
+  },
+  "drift_114": {
+   "__class__": "Drift",
+   "length": 0.025000000000034106
+  },
+  "drift_115": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_116": {
+   "__class__": "Drift",
+   "length": 2.5869999999999322
+  },
+  "drift_117": {
+   "__class__": "Drift",
+   "length": 6.7830100390000325
+  },
+  "drift_118": {
+   "__class__": "Drift",
+   "length": 0.38001934000004667
+  },
+  "drift_119": {
+   "__class__": "Drift",
+   "length": 1.1347093009999298
+  },
+  "drift_120": {
+   "__class__": "Drift",
+   "length": 0.1470000000000482
+  },
+  "drift_121": {
+   "__class__": "Drift",
+   "length": 0.015000000000043201
+  },
+  "drift_122": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_123": {
+   "__class__": "Drift",
+   "length": 0.35001003899998295
+  },
+  "drift_124": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_125": {
+   "__class__": "Drift",
+   "length": 0.3900193400000376
+  },
+  "drift_126": {
+   "__class__": "Drift",
+   "length": 0.4000193400000285
+  },
+  "drift_127": {
+   "__class__": "Drift",
+   "length": 1.7077093009999658
+  },
+  "drift_128": {
+   "__class__": "Drift",
+   "length": 0.025000000000034106
+  },
+  "drift_129": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_130": {
+   "__class__": "Drift",
+   "length": 0.7839999999999918
+  },
+  "drift_131": {
+   "__class__": "Drift",
+   "length": 0.23099999999999454
+  },
+  "drift_132": {
+   "__class__": "Drift",
+   "length": 0.23099999999999454
+  },
+  "drift_133": {
+   "__class__": "Drift",
+   "length": 0.23100000000010823
+  },
+  "drift_134": {
+   "__class__": "Drift",
+   "length": 2.342999999999961
+  },
+  "drift_135": {
+   "__class__": "Drift",
+   "length": 1.1299999999999955
+  },
+  "drift_136": {
+   "__class__": "Drift",
+   "length": 0.5109999999999673
+  },
+  "drift_137": {
+   "__class__": "Drift",
+   "length": 1.0810000000000173
+  },
+  "drift_138": {
+   "__class__": "Drift",
+   "length": 0.1369999999999436
+  },
+  "drift_139": {
+   "__class__": "Drift",
+   "length": 3.214999999999918
+  },
+  "drift_140": {
+   "__class__": "Drift",
+   "length": 1.9250000000000682
+  },
+  "drift_141": {
+   "__class__": "Drift",
+   "length": 0.5109999999999673
+  },
+  "drift_142": {
+   "__class__": "Drift",
+   "length": 0.5810000000000173
+  },
+  "drift_143": {
+   "__class__": "Drift",
+   "length": 4.828999999999951
+  },
+  "drift_144": {
+   "__class__": "Drift",
+   "length": 1.2898000000000138
+  },
+  "drift_145": {
+   "__class__": "Drift",
+   "length": 0.015000000000100044
+  },
+  "drift_146": {
+   "__class__": "Drift",
+   "length": 0.599999999999909
+  },
+  "drift_147": {
+   "__class__": "Drift",
+   "length": 1.3180000000000973
+  },
+  "drift_148": {
+   "__class__": "Drift",
+   "length": 3.7613000000000056
+  },
+  "drift_149": {
+   "__class__": "Drift",
+   "length": 1.058999999999969
+  },
+  "drift_150": {
+   "__class__": "Drift",
+   "length": 3.759999999999991
+  },
+  "drift_151": {
+   "__class__": "Drift",
+   "length": 2.213700000000017
+  },
+  "drift_152": {
+   "__class__": "Drift",
+   "length": 0.35000000000002274
+  },
+  "drift_153": {
+   "__class__": "Drift",
+   "length": 0.4660000000000082
+  },
+  "drift_154": {
+   "__class__": "Drift",
+   "length": 0.1369999999999436
+  },
+  "drift_155": {
+   "__class__": "Drift",
+   "length": 0.3369999999999891
+  },
+  "drift_156": {
+   "__class__": "Drift",
+   "length": 0.34999999999990905
+  },
+  "drift_157": {
+   "__class__": "Drift",
+   "length": 11.521000000000072
+  },
+  "drift_158": {
+   "__class__": "Drift",
+   "length": 0.2746999999999389
+  },
+  "drift_159": {
+   "__class__": "Drift",
+   "length": 0.24569999999994252
+  },
+  "drift_160": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_161": {
+   "__class__": "Drift",
+   "length": 0.6632999999999356
+  },
+  "drift_162": {
+   "__class__": "Drift",
+   "length": 11.015999999999849
+  },
+  "drift_163": {
+   "__class__": "Drift",
+   "length": 11.699000000000183
+  },
+  "drift_164": {
+   "__class__": "Drift",
+   "length": 0.3169999999998936
+  },
+  "drift_165": {
+   "__class__": "Drift",
+   "length": 0.126700000000028
+  },
+  "drift_166": {
+   "__class__": "Drift",
+   "length": 0.028999999999996362
+  },
+  "drift_167": {
+   "__class__": "Drift",
+   "length": 0.3390000000000555
+  },
+  "drift_168": {
+   "__class__": "Drift",
+   "length": 0.27800000000002
+  },
+  "drift_169": {
+   "__class__": "Drift",
+   "length": 0.19899999999995543
+  },
+  "drift_170": {
+   "__class__": "Drift",
+   "length": 0.19900000000006912
+  },
+  "drift_171": {
+   "__class__": "Drift",
+   "length": 0.19899999999995543
+  },
+  "drift_172": {
+   "__class__": "Drift",
+   "length": 0.16800000000000637
+  },
+  "drift_173": {
+   "__class__": "Drift",
+   "length": 0.4249999999999545
+  },
+  "drift_174": {
+   "__class__": "Drift",
+   "length": 0.38399999999990087
+  },
+  "drift_175": {
+   "__class__": "Drift",
+   "length": 7.005000000000109
+  },
+  "drift_176": {
+   "__class__": "Drift",
+   "length": 0.2599999999999909
+  },
+  "drift_177": {
+   "__class__": "Drift",
+   "length": 1.4049999999999727
+  },
+  "drift_178": {
+   "__class__": "Drift",
+   "length": 0.08120000000008076
+  },
+  "drift_179": {
+   "__class__": "Drift",
+   "length": 0.13249999999993634
+  },
+  "drift_180": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_181": {
+   "__class__": "Drift",
+   "length": 0.09500000000014097
+  },
+  "drift_182": {
+   "__class__": "Drift",
+   "length": 0.360010038999917
+  },
+  "drift_183": {
+   "__class__": "Drift",
+   "length": 0.4000193400000853
+  },
+  "drift_184": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_185": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_186": {
+   "__class__": "Drift",
+   "length": 1.7077093010000226
+  },
+  "drift_187": {
+   "__class__": "Drift",
+   "length": 0.014999999999986358
+  },
+  "drift_188": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_189": {
+   "__class__": "Drift",
+   "length": 0.3500100389999261
+  },
+  "drift_190": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_191": {
+   "__class__": "Drift",
+   "length": 3.063009301000079
+  },
+  "drift_192": {
+   "__class__": "Drift",
+   "length": 0.13900000000001
+  },
+  "drift_193": {
+   "__class__": "Drift",
+   "length": 3.642500000000041
+  },
+  "drift_194": {
+   "__class__": "Drift",
+   "length": 0.7081999999999198
+  },
+  "drift_195": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_196": {
+   "__class__": "Drift",
+   "length": 0.0949999999999136
+  },
+  "drift_197": {
+   "__class__": "Drift",
+   "length": 0.360010038999917
+  },
+  "drift_198": {
+   "__class__": "Drift",
+   "length": 0.4000193400000853
+  },
+  "drift_199": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_200": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_201": {
+   "__class__": "Drift",
+   "length": 0.1960093010000037
+  },
+  "drift_202": {
+   "__class__": "Drift",
+   "length": 0.7617000000001326
+  },
+  "drift_203": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_204": {
+   "__class__": "Drift",
+   "length": 0.03200000000003911
+  },
+  "drift_205": {
+   "__class__": "Drift",
+   "length": 0.1169999999999618
+  },
+  "drift_206": {
+   "__class__": "Drift",
+   "length": 0.3500100389999261
+  },
+  "drift_207": {
+   "__class__": "Drift",
+   "length": 0.3800193400001035
+  },
+  "drift_208": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_209": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_210": {
+   "__class__": "Drift",
+   "length": 0.31000930100003643
+  },
+  "drift_211": {
+   "__class__": "Drift",
+   "length": 0.08820000000002892
+  },
+  "drift_212": {
+   "__class__": "Drift",
+   "length": 0.13450000000000273
+  },
+  "drift_213": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_214": {
+   "__class__": "Drift",
+   "length": 0.0949999999999136
+  },
+  "drift_215": {
+   "__class__": "Drift",
+   "length": 0.3600100390000307
+  },
+  "drift_216": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_217": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_218": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_219": {
+   "__class__": "Drift",
+   "length": 1.1327093010000908
+  },
+  "drift_220": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_221": {
+   "__class__": "Drift",
+   "length": 0.03200000000003911
+  },
+  "drift_222": {
+   "__class__": "Drift",
+   "length": 0.1169999999999618
+  },
+  "drift_223": {
+   "__class__": "Drift",
+   "length": 0.3500100390000398
+  },
+  "drift_224": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_225": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_226": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_227": {
+   "__class__": "Drift",
+   "length": 0.2945093010000619
+  },
+  "drift_228": {
+   "__class__": "Drift",
+   "length": 0.13869999999997162
+  },
+  "drift_229": {
+   "__class__": "Drift",
+   "length": 0.13450000000000273
+  },
+  "drift_230": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_231": {
+   "__class__": "Drift",
+   "length": 0.0949999999999136
+  },
+  "drift_232": {
+   "__class__": "Drift",
+   "length": 0.3600100390000307
+  },
+  "drift_233": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_234": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_235": {
+   "__class__": "Drift",
+   "length": 0.3800193400001035
+  },
+  "drift_236": {
+   "__class__": "Drift",
+   "length": 0.2985093009999673
+  },
+  "drift_237": {
+   "__class__": "Drift",
+   "length": 0.1571999999999889
+  },
+  "drift_238": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_239": {
+   "__class__": "Drift",
+   "length": 0.014999999999986358
+  },
+  "drift_240": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_241": {
+   "__class__": "Drift",
+   "length": 0.3500100390000398
+  },
+  "drift_242": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_243": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_244": {
+   "__class__": "Drift",
+   "length": 0.4000193400000853
+  },
+  "drift_245": {
+   "__class__": "Drift",
+   "length": 0.2945093009999482
+  },
+  "drift_246": {
+   "__class__": "Drift",
+   "length": 0.7081999999999198
+  },
+  "drift_247": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_248": {
+   "__class__": "Drift",
+   "length": 0.0949999999999136
+  },
+  "drift_249": {
+   "__class__": "Drift",
+   "length": 0.3600100390000307
+  },
+  "drift_250": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_251": {
+   "__class__": "Drift",
+   "length": 0.3900193400000944
+  },
+  "drift_252": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_253": {
+   "__class__": "Drift",
+   "length": 0.3890093009999873
+  },
+  "drift_254": {
+   "__class__": "Drift",
+   "length": 0.7767000000000053
+  },
+  "drift_255": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_256": {
+   "__class__": "Drift",
+   "length": 0.09500000000014097
+  },
+  "drift_257": {
+   "__class__": "Drift",
+   "length": 0.3500100389999261
+  },
+  "drift_258": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_259": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_260": {
+   "__class__": "Drift",
+   "length": 0.4000193400000853
+  },
+  "drift_261": {
+   "__class__": "Drift",
+   "length": 0.319009301000051
+  },
+  "drift_262": {
+   "__class__": "Drift",
+   "length": 0.7327000000000226
+  },
+  "drift_263": {
+   "__class__": "Drift",
+   "length": 0.024999999999977263
+  },
+  "drift_264": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_265": {
+   "__class__": "Drift",
+   "length": 0.360010038999917
+  },
+  "drift_266": {
+   "__class__": "Drift",
+   "length": 0.4000193400000853
+  },
+  "drift_267": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_268": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_269": {
+   "__class__": "Drift",
+   "length": 1.055709300999979
+  },
+  "drift_270": {
+   "__class__": "Drift",
+   "length": 0.47700000000008913
+  },
+  "drift_271": {
+   "__class__": "Drift",
+   "length": 0.015000000000100044
+  },
+  "drift_272": {
+   "__class__": "Drift",
+   "length": 0.0949999999999136
+  },
+  "drift_273": {
+   "__class__": "Drift",
+   "length": 0.3500100389999261
+  },
+  "drift_274": {
+   "__class__": "Drift",
+   "length": 0.380019331000085
+  },
+  "drift_275": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_276": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_277": {
+   "__class__": "Drift",
+   "length": 1.138209310000093
+  },
+  "drift_278": {
+   "__class__": "Drift",
+   "length": 0.13450000000000273
+  },
+  "drift_279": {
+   "__class__": "Drift",
+   "length": 0.024999999999977263
+  },
+  "drift_280": {
+   "__class__": "Drift",
+   "length": 0.0949999999999136
+  },
+  "drift_281": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_282": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_283": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_284": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_285": {
+   "__class__": "Drift",
+   "length": 0.29850930999987213
+  },
+  "drift_286": {
+   "__class__": "Drift",
+   "length": 0.7321999999999207
+  },
+  "drift_287": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_288": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_289": {
+   "__class__": "Drift",
+   "length": 0.3500100300000213
+  },
+  "drift_290": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_291": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_292": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_293": {
+   "__class__": "Drift",
+   "length": 1.7077093099999274
+  },
+  "drift_294": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_295": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_296": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_297": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_298": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_299": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_300": {
+   "__class__": "Drift",
+   "length": 0.2985093100000995
+  },
+  "drift_301": {
+   "__class__": "Drift",
+   "length": 0.15720000000032996
+  },
+  "drift_302": {
+   "__class__": "Drift",
+   "length": 0.14899999999965985
+  },
+  "drift_303": {
+   "__class__": "Drift",
+   "length": 0.015000000000100044
+  },
+  "drift_304": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_305": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_306": {
+   "__class__": "Drift",
+   "length": 0.38001934000044457
+  },
+  "drift_307": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_308": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_309": {
+   "__class__": "Drift",
+   "length": 0.3190093099999558
+  },
+  "drift_310": {
+   "__class__": "Drift",
+   "length": 0.08120000000008076
+  },
+  "drift_311": {
+   "__class__": "Drift",
+   "length": 0.1325000000001637
+  },
+  "drift_312": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_313": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_314": {
+   "__class__": "Drift",
+   "length": 0.3600100299997848
+  },
+  "drift_315": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_316": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_317": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_318": {
+   "__class__": "Drift",
+   "length": 0.1960093099999085
+  },
+  "drift_319": {
+   "__class__": "Drift",
+   "length": 0.7617000000002463
+  },
+  "drift_320": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_321": {
+   "__class__": "Drift",
+   "length": 0.015000000000100044
+  },
+  "drift_322": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_323": {
+   "__class__": "Drift",
+   "length": 0.3500100300000213
+  },
+  "drift_324": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_325": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_326": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_327": {
+   "__class__": "Drift",
+   "length": 0.43555458999981056
+  },
+  "drift_328": {
+   "__class__": "Drift",
+   "length": 0.4276547199999641
+  },
+  "drift_329": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_330": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_331": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_332": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_333": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_334": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_335": {
+   "__class__": "Drift",
+   "length": 0.38001934000044457
+  },
+  "drift_336": {
+   "__class__": "Drift",
+   "length": 0.29850930999987213
+  },
+  "drift_337": {
+   "__class__": "Drift",
+   "length": 0.1572000000001026
+  },
+  "drift_338": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_339": {
+   "__class__": "Drift",
+   "length": 0.015000000000100044
+  },
+  "drift_340": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_341": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_342": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_343": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_344": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_345": {
+   "__class__": "Drift",
+   "length": 1.1305545900002016
+  },
+  "drift_346": {
+   "__class__": "Drift",
+   "length": 0.3021547199998622
+  },
+  "drift_347": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_348": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_349": {
+   "__class__": "Drift",
+   "length": 0.3600100299997848
+  },
+  "drift_350": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_351": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_352": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_353": {
+   "__class__": "Drift",
+   "length": 0.8127093099999456
+  },
+  "drift_354": {
+   "__class__": "Drift",
+   "length": 0.3550000000000182
+  },
+  "drift_355": {
+   "__class__": "Drift",
+   "length": 0.09000000000014552
+  },
+  "drift_356": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_357": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_358": {
+   "__class__": "Drift",
+   "length": 0.3500100300000213
+  },
+  "drift_359": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_360": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_361": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_362": {
+   "__class__": "Drift",
+   "length": 0.31000930999994125
+  },
+  "drift_363": {
+   "__class__": "Drift",
+   "length": 0.6576999999999771
+  },
+  "drift_364": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_365": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_366": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_367": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_368": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_369": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_370": {
+   "__class__": "Drift",
+   "length": 0.29850930999987213
+  },
+  "drift_371": {
+   "__class__": "Drift",
+   "length": 0.3671999999999116
+  },
+  "drift_372": {
+   "__class__": "Drift",
+   "length": 0.09000000000014552
+  },
+  "drift_373": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_374": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_375": {
+   "__class__": "Drift",
+   "length": 0.3500100300000213
+  },
+  "drift_376": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_377": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_378": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_379": {
+   "__class__": "Drift",
+   "length": 0.2942093100002694
+  },
+  "drift_380": {
+   "__class__": "Drift",
+   "length": 0.1390000000001237
+  },
+  "drift_381": {
+   "__class__": "Drift",
+   "length": 0.13449999999988904
+  },
+  "drift_382": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_383": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_384": {
+   "__class__": "Drift",
+   "length": 0.36001003000023957
+  },
+  "drift_385": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_386": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_387": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_388": {
+   "__class__": "Drift",
+   "length": 0.4260093099999267
+  },
+  "drift_389": {
+   "__class__": "Drift",
+   "length": 1.0457000000001244
+  },
+  "drift_390": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_391": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_392": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_393": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_394": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_395": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_396": {
+   "__class__": "Drift",
+   "length": 0.2060093100001268
+  },
+  "drift_397": {
+   "__class__": "Drift",
+   "length": 0.6416999999999007
+  },
+  "drift_398": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_399": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_400": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_401": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_402": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_403": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_404": {
+   "__class__": "Drift",
+   "length": 1.132709309999882
+  },
+  "drift_405": {
+   "__class__": "Drift",
+   "length": 0.1490000000001146
+  },
+  "drift_406": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_407": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_408": {
+   "__class__": "Drift",
+   "length": 0.3500100300000213
+  },
+  "drift_409": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_410": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_411": {
+   "__class__": "Drift",
+   "length": 0.4000193400004264
+  },
+  "drift_412": {
+   "__class__": "Drift",
+   "length": 0.3110093099999176
+  },
+  "drift_413": {
+   "__class__": "Drift",
+   "length": 0.11320000000000618
+  },
+  "drift_414": {
+   "__class__": "Drift",
+   "length": 0.13449999999988904
+  },
+  "drift_415": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_416": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_417": {
+   "__class__": "Drift",
+   "length": 0.36001003000023957
+  },
+  "drift_418": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_419": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_420": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_421": {
+   "__class__": "Drift",
+   "length": 0.19600931000036326
+  },
+  "drift_422": {
+   "__class__": "Drift",
+   "length": 0.16899999999986903
+  },
+  "drift_423": {
+   "__class__": "Drift",
+   "length": 0.31970000000001164
+  },
+  "drift_424": {
+   "__class__": "Drift",
+   "length": 0.14699999999993452
+  },
+  "drift_425": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_426": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_427": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_428": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_429": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_430": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_431": {
+   "__class__": "Drift",
+   "length": 0.4677093100001457
+  },
+  "drift_432": {
+   "__class__": "Drift",
+   "length": 0.0724999999999909
+  },
+  "drift_433": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_434": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_435": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_436": {
+   "__class__": "Drift",
+   "length": 0.4679999999998472
+  },
+  "drift_437": {
+   "__class__": "Drift",
+   "length": 0.40200000000004366
+  },
+  "drift_438": {
+   "__class__": "Drift",
+   "length": 0.262000000000171
+  },
+  "drift_439": {
+   "__class__": "Drift",
+   "length": 0.6000000000001364
+  },
+  "drift_440": {
+   "__class__": "Drift",
+   "length": 0.2599999999999909
+  },
+  "drift_441": {
+   "__class__": "Drift",
+   "length": 0.2599999999999909
+  },
+  "drift_442": {
+   "__class__": "Drift",
+   "length": 0.9800000000000182
+  },
+  "drift_443": {
+   "__class__": "Drift",
+   "length": 0.48401002999980847
+  },
+  "drift_444": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_445": {
+   "__class__": "Drift",
+   "length": 0.5400093100001868
+  },
+  "drift_446": {
+   "__class__": "Drift",
+   "length": 0.31979999999998654
+  },
+  "drift_447": {
+   "__class__": "Drift",
+   "length": 0.14699999999993452
+  },
+  "drift_448": {
+   "__class__": "Drift",
+   "length": 0.015000000000100044
+  },
+  "drift_449": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_450": {
+   "__class__": "Drift",
+   "length": 0.3500100300000213
+  },
+  "drift_451": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_452": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_453": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_454": {
+   "__class__": "Drift",
+   "length": 0.2977093099998456
+  },
+  "drift_455": {
+   "__class__": "Drift",
+   "length": 0.09199999999987085
+  },
+  "drift_456": {
+   "__class__": "Drift",
+   "length": 0.009000000000014552
+  },
+  "drift_457": {
+   "__class__": "Drift",
+   "length": 0.18699999999989814
+  },
+  "drift_458": {
+   "__class__": "Drift",
+   "length": 0.30700000000001637
+  },
+  "drift_459": {
+   "__class__": "Drift",
+   "length": 1.0040000000001328
+  },
+  "drift_460": {
+   "__class__": "Drift",
+   "length": 0.125
+  },
+  "drift_461": {
+   "__class__": "Drift",
+   "length": 0.12499999999977263
+  },
+  "drift_462": {
+   "__class__": "Drift",
+   "length": 0.125
+  },
+  "drift_463": {
+   "__class__": "Drift",
+   "length": 0.12500000000022737
+  },
+  "drift_464": {
+   "__class__": "Drift",
+   "length": 0.12499999999977263
+  },
+  "drift_465": {
+   "__class__": "Drift",
+   "length": 0.125
+  },
+  "drift_466": {
+   "__class__": "Drift",
+   "length": 0.125
+  },
+  "drift_467": {
+   "__class__": "Drift",
+   "length": 0.12499999999977263
+  },
+  "drift_468": {
+   "__class__": "Drift",
+   "length": 0.125
+  },
+  "drift_469": {
+   "__class__": "Drift",
+   "length": 0.12500000000022737
+  },
+  "drift_470": {
+   "__class__": "Drift",
+   "length": 1.835999999999558
+  },
+  "drift_471": {
+   "__class__": "Drift",
+   "length": 0.15000000000031832
+  },
+  "drift_472": {
+   "__class__": "Drift",
+   "length": 0.25399999999967804
+  },
+  "drift_473": {
+   "__class__": "Drift",
+   "length": 0.2500000000002274
+  },
+  "drift_474": {
+   "__class__": "Drift",
+   "length": 0.14799999999991087
+  },
+  "drift_475": {
+   "__class__": "Drift",
+   "length": 0.4516999999998461
+  },
+  "drift_476": {
+   "__class__": "Drift",
+   "length": 0.777000000000271
+  },
+  "drift_477": {
+   "__class__": "Drift",
+   "length": 10.086999999999989
+  },
+  "drift_478": {
+   "__class__": "Drift",
+   "length": 0.16200000000026193
+  },
+  "drift_479": {
+   "__class__": "Drift",
+   "length": 0.16200000000003456
+  },
+  "drift_480": {
+   "__class__": "Drift",
+   "length": 0.1619999999998072
+  },
+  "drift_481": {
+   "__class__": "Drift",
+   "length": 0.16200000000003456
+  },
+  "drift_482": {
+   "__class__": "Drift",
+   "length": 0.1619999999998072
+  },
+  "drift_483": {
+   "__class__": "Drift",
+   "length": 0.16200000000003456
+  },
+  "drift_484": {
+   "__class__": "Drift",
+   "length": 0.5299999999999727
+  },
+  "drift_485": {
+   "__class__": "Drift",
+   "length": 0.22600000000011278
+  },
+  "drift_486": {
+   "__class__": "Drift",
+   "length": 0.19000000000005457
+  },
+  "drift_487": {
+   "__class__": "Drift",
+   "length": 0.3609999999998763
+  },
+  "drift_488": {
+   "__class__": "Drift",
+   "length": 0.31670000000030996
+  },
+  "drift_489": {
+   "__class__": "Drift",
+   "length": 0.6099999999999
+  },
+  "drift_490": {
+   "__class__": "Drift",
+   "length": 0.1619999999998072
+  },
+  "drift_491": {
+   "__class__": "Drift",
+   "length": 0.16200000000003456
+  },
+  "drift_492": {
+   "__class__": "Drift",
+   "length": 0.16200000000003456
+  },
+  "drift_493": {
+   "__class__": "Drift",
+   "length": 0.1619999999998072
+  },
+  "drift_494": {
+   "__class__": "Drift",
+   "length": 0.16200000000003456
+  },
+  "drift_495": {
+   "__class__": "Drift",
+   "length": 0.1619999999998072
+  },
+  "drift_496": {
+   "__class__": "Drift",
+   "length": 0.16200000000003456
+  },
+  "drift_497": {
+   "__class__": "Drift",
+   "length": 0.16200000000026193
+  },
+  "drift_498": {
+   "__class__": "Drift",
+   "length": 0.1619999999998072
+  },
+  "drift_499": {
+   "__class__": "Drift",
+   "length": 0.16200000000003456
+  },
+  "drift_500": {
+   "__class__": "Drift",
+   "length": 1.0597000000000207
+  },
+  "drift_501": {
+   "__class__": "Drift",
+   "length": 1.125
+  },
+  "drift_502": {
+   "__class__": "Drift",
+   "length": 6.877299999999877
+  },
+  "drift_503": {
+   "__class__": "Drift",
+   "length": 1.1097000000002026
+  },
+  "drift_504": {
+   "__class__": "Drift",
+   "length": 0.2719999999999345
+  },
+  "drift_505": {
+   "__class__": "Drift",
+   "length": 0.32799999999997453
+  },
+  "drift_506": {
+   "__class__": "Drift",
+   "length": 18.76649999999995
+  },
+  "drift_507": {
+   "__class__": "Drift",
+   "length": 0.5205000000000837
+  },
+  "drift_508": {
+   "__class__": "Drift",
+   "length": 0.5
+  },
+  "drift_509": {
+   "__class__": "Drift",
+   "length": 1.2530000000001564
+  },
+  "drift_510": {
+   "__class__": "Drift",
+   "length": 0.08119999999985339
+  },
+  "drift_511": {
+   "__class__": "Drift",
+   "length": 0.1325000000001637
+  },
+  "drift_512": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_513": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_514": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_515": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_516": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_517": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_518": {
+   "__class__": "Drift",
+   "length": 0.5400093100001868
+  },
+  "drift_519": {
+   "__class__": "Drift",
+   "length": 0.892699999999877
+  },
+  "drift_520": {
+   "__class__": "Drift",
+   "length": 0.015000000000100044
+  },
+  "drift_521": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_522": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_523": {
+   "__class__": "Drift",
+   "length": 0.38001934000044457
+  },
+  "drift_524": {
+   "__class__": "Drift",
+   "length": 0.996009309999863
+  },
+  "drift_525": {
+   "__class__": "Drift",
+   "length": 2.2625000000000455
+  },
+  "drift_526": {
+   "__class__": "Drift",
+   "length": 4.949200000000019
+  },
+  "drift_527": {
+   "__class__": "Drift",
+   "length": 1.2788000000000466
+  },
+  "drift_528": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_529": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_530": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_531": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_532": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_533": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_534": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_535": {
+   "__class__": "Drift",
+   "length": 0.19600931000036326
+  },
+  "drift_536": {
+   "__class__": "Drift",
+   "length": 0.16899999999986903
+  },
+  "drift_537": {
+   "__class__": "Drift",
+   "length": 0.31770000000005894
+  },
+  "drift_538": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_539": {
+   "__class__": "Drift",
+   "length": 0.03199999999992542
+  },
+  "drift_540": {
+   "__class__": "Drift",
+   "length": 0.1169999999999618
+  },
+  "drift_541": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_542": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_543": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_544": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_545": {
+   "__class__": "Drift",
+   "length": 0.31000930999994125
+  },
+  "drift_546": {
+   "__class__": "Drift",
+   "length": 0.08820000000014261
+  },
+  "drift_547": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_548": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_549": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_550": {
+   "__class__": "Drift",
+   "length": 0.3600100299997848
+  },
+  "drift_551": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_552": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_553": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_554": {
+   "__class__": "Drift",
+   "length": 1.1327093100001093
+  },
+  "drift_555": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_556": {
+   "__class__": "Drift",
+   "length": 0.015000000000100044
+  },
+  "drift_557": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_558": {
+   "__class__": "Drift",
+   "length": 0.3500100300000213
+  },
+  "drift_559": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_560": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_561": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_562": {
+   "__class__": "Drift",
+   "length": 0.2945093099999667
+  },
+  "drift_563": {
+   "__class__": "Drift",
+   "length": 0.13869999999997162
+  },
+  "drift_564": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_565": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_566": {
+   "__class__": "Drift",
+   "length": 0.09500000000002728
+  },
+  "drift_567": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_568": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_569": {
+   "__class__": "Drift",
+   "length": 0.3900193400002081
+  },
+  "drift_570": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_571": {
+   "__class__": "Drift",
+   "length": 0.29850930999987213
+  },
+  "drift_572": {
+   "__class__": "Drift",
+   "length": 0.1572000000001026
+  },
+  "drift_573": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_574": {
+   "__class__": "Drift",
+   "length": 0.03199999999992542
+  },
+  "drift_575": {
+   "__class__": "Drift",
+   "length": 0.1169999999999618
+  },
+  "drift_576": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_577": {
+   "__class__": "Drift",
+   "length": 0.3800193399999898
+  },
+  "drift_578": {
+   "__class__": "Drift",
+   "length": 0.39001933999975336
+  },
+  "drift_579": {
+   "__class__": "Drift",
+   "length": 0.40001933999997163
+  },
+  "drift_580": {
+   "__class__": "Drift",
+   "length": 0.2945093100001941
+  },
+  "drift_581": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_582": {
+   "__class__": "Drift",
+   "length": 0.024999999999863576
+  },
+  "drift_583": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_584": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_585": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_586": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_587": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_588": {
+   "__class__": "Drift",
+   "length": 0.38900930999989214
+  },
+  "drift_589": {
+   "__class__": "Drift",
+   "length": 0.7766999999998916
+  },
+  "drift_590": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_591": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_592": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_593": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_594": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_595": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_596": {
+   "__class__": "Drift",
+   "length": 0.31900930999972843
+  },
+  "drift_597": {
+   "__class__": "Drift",
+   "length": 0.7327000000000226
+  },
+  "drift_598": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_599": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_600": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_601": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_602": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_603": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_604": {
+   "__class__": "Drift",
+   "length": 1.0557093100001111
+  },
+  "drift_605": {
+   "__class__": "Drift",
+   "length": 0.4770000000003165
+  },
+  "drift_606": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_607": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_608": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_609": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_610": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_611": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_612": {
+   "__class__": "Drift",
+   "length": 1.138209310000093
+  },
+  "drift_613": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_614": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_615": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_616": {
+   "__class__": "Drift",
+   "length": 0.36001002999955745
+  },
+  "drift_617": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_618": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_619": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_620": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_621": {
+   "__class__": "Drift",
+   "length": 0.7321999999999207
+  },
+  "drift_622": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_623": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_624": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_625": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_626": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_627": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_628": {
+   "__class__": "Drift",
+   "length": 1.7077093100001548
+  },
+  "drift_629": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_630": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_631": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_632": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_633": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_634": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_635": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_636": {
+   "__class__": "Drift",
+   "length": 0.15720000000055734
+  },
+  "drift_637": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_638": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_639": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_640": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_641": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_642": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_643": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_644": {
+   "__class__": "Drift",
+   "length": 0.3190093100006379
+  },
+  "drift_645": {
+   "__class__": "Drift",
+   "length": 0.16319999999950596
+  },
+  "drift_646": {
+   "__class__": "Drift",
+   "length": 0.13450000000057116
+  },
+  "drift_647": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_648": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_649": {
+   "__class__": "Drift",
+   "length": 0.36001002999955745
+  },
+  "drift_650": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_651": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_652": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_653": {
+   "__class__": "Drift",
+   "length": 0.4943093100000624
+  },
+  "drift_654": {
+   "__class__": "Drift",
+   "length": 0.46339999999963766
+  },
+  "drift_655": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_656": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_657": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_658": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_659": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_660": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_661": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_662": {
+   "__class__": "Drift",
+   "length": 0.30900930999951015
+  },
+  "drift_663": {
+   "__class__": "Drift",
+   "length": 0.1312000000007174
+  },
+  "drift_664": {
+   "__class__": "Drift",
+   "length": 0.13449999999966167
+  },
+  "drift_665": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_666": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_667": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_668": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_669": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_670": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_671": {
+   "__class__": "Drift",
+   "length": 1.1327093099994272
+  },
+  "drift_672": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_673": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_674": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_675": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_676": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_677": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_678": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_679": {
+   "__class__": "Drift",
+   "length": 1.7077093100001548
+  },
+  "drift_680": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_681": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_682": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_683": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_684": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_685": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_686": {
+   "__class__": "Drift",
+   "length": 1.7077093100001548
+  },
+  "drift_687": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_688": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_689": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_690": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_691": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_692": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_693": {
+   "__class__": "Drift",
+   "length": 0.30900930999951015
+  },
+  "drift_694": {
+   "__class__": "Drift",
+   "length": 0.7007000000003245
+  },
+  "drift_695": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_696": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_697": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_698": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_699": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_700": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_701": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_702": {
+   "__class__": "Drift",
+   "length": 0.08019999999987704
+  },
+  "drift_703": {
+   "__class__": "Drift",
+   "length": 0.47699999999986176
+  },
+  "drift_704": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_705": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_706": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_707": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_708": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_709": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_710": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_711": {
+   "__class__": "Drift",
+   "length": 0.13870000000042637
+  },
+  "drift_712": {
+   "__class__": "Drift",
+   "length": 0.13449999999966167
+  },
+  "drift_713": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_714": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_715": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_716": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_717": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_718": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_719": {
+   "__class__": "Drift",
+   "length": 0.7272093100000347
+  },
+  "drift_720": {
+   "__class__": "Drift",
+   "length": 0.47000000000025466
+  },
+  "drift_721": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_722": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_723": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_724": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_725": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_726": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_727": {
+   "__class__": "Drift",
+   "length": 1.7077093100001548
+  },
+  "drift_728": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_729": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_730": {
+   "__class__": "Drift",
+   "length": 0.36001002999955745
+  },
+  "drift_731": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_732": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_733": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_734": {
+   "__class__": "Drift",
+   "length": 0.19570930999952907
+  },
+  "drift_735": {
+   "__class__": "Drift",
+   "length": 0.0770000000006803
+  },
+  "drift_736": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_737": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_738": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_739": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_740": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_741": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_742": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_743": {
+   "__class__": "Drift",
+   "length": 0.46800930999961565
+  },
+  "drift_744": {
+   "__class__": "Drift",
+   "length": 0.07220000000006621
+  },
+  "drift_745": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_746": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_747": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_748": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_749": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_750": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_751": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_752": {
+   "__class__": "Drift",
+   "length": 0.19600931000013588
+  },
+  "drift_753": {
+   "__class__": "Drift",
+   "length": 0.07680000000027576
+  },
+  "drift_754": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_755": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_756": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_757": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_758": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_759": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_760": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_761": {
+   "__class__": "Drift",
+   "length": 0.30900930999951015
+  },
+  "drift_762": {
+   "__class__": "Drift",
+   "length": 0.13120000000026266
+  },
+  "drift_763": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_764": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_765": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_766": {
+   "__class__": "Drift",
+   "length": 6.956000000000131
+  },
+  "drift_767": {
+   "__class__": "Drift",
+   "length": 3.161999999999807
+  },
+  "drift_768": {
+   "__class__": "Drift",
+   "length": 0.9689999999995962
+  },
+  "drift_769": {
+   "__class__": "Drift",
+   "length": 0.8070100300001286
+  },
+  "drift_770": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_771": {
+   "__class__": "Drift",
+   "length": 0.4900093100000049
+  },
+  "drift_772": {
+   "__class__": "Drift",
+   "length": 0.07860000000027867
+  },
+  "drift_773": {
+   "__class__": "Drift",
+   "length": 0.14699999999947977
+  },
+  "drift_774": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_775": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_776": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_777": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_778": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_779": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_780": {
+   "__class__": "Drift",
+   "length": 1.2157093099995109
+  },
+  "drift_781": {
+   "__class__": "Drift",
+   "length": 0.21700000000009823
+  },
+  "drift_782": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_783": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_784": {
+   "__class__": "Drift",
+   "length": 0.16600000000016735
+  },
+  "drift_785": {
+   "__class__": "Drift",
+   "length": 0.7029999999999745
+  },
+  "drift_786": {
+   "__class__": "Drift",
+   "length": 0.7029999999995198
+  },
+  "drift_787": {
+   "__class__": "Drift",
+   "length": 0.7029999999999745
+  },
+  "drift_788": {
+   "__class__": "Drift",
+   "length": 0.7029999999999745
+  },
+  "drift_789": {
+   "__class__": "Drift",
+   "length": 0.09069999999974243
+  },
+  "drift_790": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_791": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_792": {
+   "__class__": "Drift",
+   "length": 0.298200000000179
+  },
+  "drift_793": {
+   "__class__": "Drift",
+   "length": 0.0003500000002532033
+  },
+  "drift_794": {
+   "__class__": "Drift",
+   "length": 0.43928500000038184
+  },
+  "drift_795": {
+   "__class__": "Drift",
+   "length": 0.15093500000011772
+  },
+  "drift_796": {
+   "__class__": "Drift",
+   "length": 0.7029999999995198
+  },
+  "drift_797": {
+   "__class__": "Drift",
+   "length": 0.7029999999995198
+  },
+  "drift_798": {
+   "__class__": "Drift",
+   "length": 0.5479999999997744
+  },
+  "drift_799": {
+   "__class__": "Drift",
+   "length": 0.07949999999982538
+  },
+  "drift_800": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_801": {
+   "__class__": "Drift",
+   "length": 0.08900459999949817
+  },
+  "drift_802": {
+   "__class__": "Drift",
+   "length": 0.005995400000301743
+  },
+  "drift_803": {
+   "__class__": "Drift",
+   "length": 0.1659999999997126
+  },
+  "drift_804": {
+   "__class__": "Drift",
+   "length": 0.7029999999999745
+  },
+  "drift_805": {
+   "__class__": "Drift",
+   "length": 0.7029999999999745
+  },
+  "drift_806": {
+   "__class__": "Drift",
+   "length": 0.7029999999995198
+  },
+  "drift_807": {
+   "__class__": "Drift",
+   "length": 0.7029999999999745
+  },
+  "drift_808": {
+   "__class__": "Drift",
+   "length": 0.09069999999974243
+  },
+  "drift_809": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_810": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_811": {
+   "__class__": "Drift",
+   "length": 0.3360000000002401
+  },
+  "drift_812": {
+   "__class__": "Drift",
+   "length": 0.17000000000007276
+  },
+  "drift_813": {
+   "__class__": "Drift",
+   "length": 0.9339999999997417
+  },
+  "drift_814": {
+   "__class__": "Drift",
+   "length": 0.5759349999998449
+  },
+  "drift_815": {
+   "__class__": "Drift",
+   "length": 0.15093500000011772
+  },
+  "drift_816": {
+   "__class__": "Drift",
+   "length": 0.7029999999995198
+  },
+  "drift_817": {
+   "__class__": "Drift",
+   "length": 0.7029999999995198
+  },
+  "drift_818": {
+   "__class__": "Drift",
+   "length": 1.5284999999998945
+  },
+  "drift_819": {
+   "__class__": "Drift",
+   "length": 0.08120000000053551
+  },
+  "drift_820": {
+   "__class__": "Drift",
+   "length": 0.13249999999970896
+  },
+  "drift_821": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_822": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_823": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_824": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_825": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_826": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_827": {
+   "__class__": "Drift",
+   "length": 0.19600930999968114
+  },
+  "drift_828": {
+   "__class__": "Drift",
+   "length": 0.6516999999998916
+  },
+  "drift_829": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_830": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_831": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_832": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_833": {
+   "__class__": "Drift",
+   "length": 0.49800930999981574
+  },
+  "drift_834": {
+   "__class__": "Drift",
+   "length": 0.3020000000001346
+  },
+  "drift_835": {
+   "__class__": "Drift",
+   "length": 0.23199999999951615
+  },
+  "drift_836": {
+   "__class__": "Drift",
+   "length": 10.666499999999814
+  },
+  "drift_837": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_838": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_839": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_840": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_841": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_842": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_843": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_844": {
+   "__class__": "Drift",
+   "length": 0.49430930999960765
+  },
+  "drift_845": {
+   "__class__": "Drift",
+   "length": 0.46339999999963766
+  },
+  "drift_846": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_847": {
+   "__class__": "Drift",
+   "length": 0.032000000000152795
+  },
+  "drift_848": {
+   "__class__": "Drift",
+   "length": 0.11699999999973443
+  },
+  "drift_849": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_850": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_851": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_852": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_853": {
+   "__class__": "Drift",
+   "length": 0.3100093100001686
+  },
+  "drift_854": {
+   "__class__": "Drift",
+   "length": 0.08820000000014261
+  },
+  "drift_855": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_856": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_857": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_858": {
+   "__class__": "Drift",
+   "length": 0.36001002999955745
+  },
+  "drift_859": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_860": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_861": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_862": {
+   "__class__": "Drift",
+   "length": 1.1327093100003367
+  },
+  "drift_863": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_864": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_865": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_866": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_867": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_868": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_869": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_870": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_871": {
+   "__class__": "Drift",
+   "length": 0.13869999999997162
+  },
+  "drift_872": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_873": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_874": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_875": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_876": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_877": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_878": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_879": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_880": {
+   "__class__": "Drift",
+   "length": 0.1572000000001026
+  },
+  "drift_881": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_882": {
+   "__class__": "Drift",
+   "length": 0.032000000000152795
+  },
+  "drift_883": {
+   "__class__": "Drift",
+   "length": 0.11700000000018917
+  },
+  "drift_884": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_885": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_886": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_887": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_888": {
+   "__class__": "Drift",
+   "length": 0.2945093100001941
+  },
+  "drift_889": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_890": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_891": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_892": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_893": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_894": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_895": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_896": {
+   "__class__": "Drift",
+   "length": 0.38900930999989214
+  },
+  "drift_897": {
+   "__class__": "Drift",
+   "length": 0.7767000000003463
+  },
+  "drift_898": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_899": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_900": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_901": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_902": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_903": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_904": {
+   "__class__": "Drift",
+   "length": 0.3190093100001832
+  },
+  "drift_905": {
+   "__class__": "Drift",
+   "length": 0.6486999999997352
+  },
+  "drift_906": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_907": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_908": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_909": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_910": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_911": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_912": {
+   "__class__": "Drift",
+   "length": 1.0787093099997946
+  },
+  "drift_913": {
+   "__class__": "Drift",
+   "length": 0.4539999999997235
+  },
+  "drift_914": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_915": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_916": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_917": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_918": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_919": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_920": {
+   "__class__": "Drift",
+   "length": 1.1382093099996382
+  },
+  "drift_921": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_922": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_923": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_924": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_925": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_926": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_927": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_928": {
+   "__class__": "Drift",
+   "length": 0.2985093100000995
+  },
+  "drift_929": {
+   "__class__": "Drift",
+   "length": 0.7321999999999207
+  },
+  "drift_930": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_931": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_932": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_933": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_934": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_935": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_936": {
+   "__class__": "Drift",
+   "length": 0.8381093100001635
+  },
+  "drift_937": {
+   "__class__": "Drift",
+   "length": 0.1475999999997839
+  },
+  "drift_938": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_939": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_940": {
+   "__class__": "Drift",
+   "length": 0.36001002999955745
+  },
+  "drift_941": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_942": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_943": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_944": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_945": {
+   "__class__": "Drift",
+   "length": 0.1572000000001026
+  },
+  "drift_946": {
+   "__class__": "Drift",
+   "length": 0.14899999999988722
+  },
+  "drift_947": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_948": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_949": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_950": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_951": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_952": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_953": {
+   "__class__": "Drift",
+   "length": 0.31900930999972843
+  },
+  "drift_954": {
+   "__class__": "Drift",
+   "length": 0.08120000000008076
+  },
+  "drift_955": {
+   "__class__": "Drift",
+   "length": 0.1325000000001637
+  },
+  "drift_956": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_957": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_958": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_959": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_960": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_961": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_962": {
+   "__class__": "Drift",
+   "length": 0.4943093100000624
+  },
+  "drift_963": {
+   "__class__": "Drift",
+   "length": 0.46339999999963766
+  },
+  "drift_964": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_965": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_966": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_967": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_968": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_969": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_970": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_971": {
+   "__class__": "Drift",
+   "length": 1.138209310000093
+  },
+  "drift_972": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_973": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_974": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_975": {
+   "__class__": "Drift",
+   "length": 0.36001002999955745
+  },
+  "drift_976": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_977": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_978": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_979": {
+   "__class__": "Drift",
+   "length": 0.2985093100000995
+  },
+  "drift_980": {
+   "__class__": "Drift",
+   "length": 0.1572000000001026
+  },
+  "drift_981": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_982": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_983": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_984": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_985": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_986": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_987": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_988": {
+   "__class__": "Drift",
+   "length": 0.31900930999972843
+  },
+  "drift_989": {
+   "__class__": "Drift",
+   "length": 0.6487000000001899
+  },
+  "drift_990": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_991": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_992": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_993": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_994": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_995": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_996": {
+   "__class__": "Drift",
+   "length": 1.7077093099997
+  },
+  "drift_997": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_998": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_999": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1000": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1001": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1002": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1003": {
+   "__class__": "Drift",
+   "length": 0.3100093100001686
+  },
+  "drift_1004": {
+   "__class__": "Drift",
+   "length": 0.6577000000002045
+  },
+  "drift_1005": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1006": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1007": {
+   "__class__": "Drift",
+   "length": 0.36001002999955745
+  },
+  "drift_1008": {
+   "__class__": "Drift",
+   "length": 0.400019340000199
+  },
+  "drift_1009": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1010": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1011": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_1012": {
+   "__class__": "Drift",
+   "length": 0.08019999999987704
+  },
+  "drift_1013": {
+   "__class__": "Drift",
+   "length": 0.4770000000003165
+  },
+  "drift_1014": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_1015": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_1016": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1017": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1018": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_1019": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1020": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_1021": {
+   "__class__": "Drift",
+   "length": 0.13870000000042637
+  },
+  "drift_1022": {
+   "__class__": "Drift",
+   "length": 0.13449999999966167
+  },
+  "drift_1023": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1024": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1025": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1026": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1027": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_1028": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1029": {
+   "__class__": "Drift",
+   "length": 1.7077093099997
+  },
+  "drift_1030": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_1031": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1032": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1033": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1034": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1035": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1036": {
+   "__class__": "Drift",
+   "length": 1.7077093100001548
+  },
+  "drift_1037": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_1038": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_1039": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1040": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1041": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1042": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1043": {
+   "__class__": "Drift",
+   "length": 1.1328093099996295
+  },
+  "drift_1044": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_1045": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_1046": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1047": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1048": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1049": {
+   "__class__": "Drift",
+   "length": 0.39001933999998073
+  },
+  "drift_1050": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1051": {
+   "__class__": "Drift",
+   "length": 1.1382093099996382
+  },
+  "drift_1052": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1053": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_1054": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_1055": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1056": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1057": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1058": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1059": {
+   "__class__": "Drift",
+   "length": 0.19600931000013588
+  },
+  "drift_1060": {
+   "__class__": "Drift",
+   "length": 0.16899999999986903
+  },
+  "drift_1061": {
+   "__class__": "Drift",
+   "length": 0.36869999999953507
+  },
+  "drift_1062": {
+   "__class__": "Drift",
+   "length": 0.09800000000041109
+  },
+  "drift_1063": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1064": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1065": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1066": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1067": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1068": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1069": {
+   "__class__": "Drift",
+   "length": 0.2910093099999358
+  },
+  "drift_1070": {
+   "__class__": "Drift",
+   "length": 0.13520000000016807
+  },
+  "drift_1071": {
+   "__class__": "Drift",
+   "length": 0.1325000000001637
+  },
+  "drift_1072": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1073": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1074": {
+   "__class__": "Drift",
+   "length": 0.307999999999538
+  },
+  "drift_1075": {
+   "__class__": "Drift",
+   "length": 2.5549999999998363
+  },
+  "drift_1076": {
+   "__class__": "Drift",
+   "length": 0.7699999999999818
+  },
+  "drift_1077": {
+   "__class__": "Drift",
+   "length": 8.141010029999961
+  },
+  "drift_1078": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1079": {
+   "__class__": "Drift",
+   "length": 0.3700093100005688
+  },
+  "drift_1080": {
+   "__class__": "Drift",
+   "length": 0.2096999999998843
+  },
+  "drift_1081": {
+   "__class__": "Drift",
+   "length": 0.14699999999993452
+  },
+  "drift_1082": {
+   "__class__": "Drift",
+   "length": 0.01499999999987267
+  },
+  "drift_1083": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_1084": {
+   "__class__": "Drift",
+   "length": 0.35001003000024866
+  },
+  "drift_1085": {
+   "__class__": "Drift",
+   "length": 0.38001933999976245
+  },
+  "drift_1086": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1087": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1088": {
+   "__class__": "Drift",
+   "length": 1.7077093100001548
+  },
+  "drift_1089": {
+   "__class__": "Drift",
+   "length": 0.02500000000009095
+  },
+  "drift_1090": {
+   "__class__": "Drift",
+   "length": 0.09499999999979991
+  },
+  "drift_1091": {
+   "__class__": "Drift",
+   "length": 0.27799999999979264
+  },
+  "drift_1092": {
+   "__class__": "Drift",
+   "length": 0.08099999999967622
+  },
+  "drift_1093": {
+   "__class__": "Drift",
+   "length": 0.29899999999997817
+  },
+  "drift_1094": {
+   "__class__": "Drift",
+   "length": 0.29899999999997817
+  },
+  "drift_1095": {
+   "__class__": "Drift",
+   "length": 0.29899999999997817
+  },
+  "drift_1096": {
+   "__class__": "Drift",
+   "length": 2.5309999999994943
+  },
+  "drift_1097": {
+   "__class__": "Drift",
+   "length": 0.16500000000041837
+  },
+  "drift_1098": {
+   "__class__": "Drift",
+   "length": 3.6539999999999964
+  },
+  "drift_1099": {
+   "__class__": "Drift",
+   "length": 0.13700000000017099
+  },
+  "drift_1100": {
+   "__class__": "Drift",
+   "length": 6.391999999999825
+  },
+  "drift_1101": {
+   "__class__": "Drift",
+   "length": 1.1606999999999061
+  },
+  "drift_1102": {
+   "__class__": "Drift",
+   "length": 0.13299999999981083
+  },
+  "drift_1103": {
+   "__class__": "Drift",
+   "length": 0.4670000000000982
+  },
+  "drift_1104": {
+   "__class__": "Drift",
+   "length": 0.6099999999996726
+  },
+  "drift_1105": {
+   "__class__": "Drift",
+   "length": 6.510999999999967
+  },
+  "drift_1106": {
+   "__class__": "Drift",
+   "length": 0.8949999999999818
+  },
+  "drift_1107": {
+   "__class__": "Drift",
+   "length": 5.148499999999785
+  },
+  "drift_1108": {
+   "__class__": "Drift",
+   "length": 0.10870000000022628
+  },
+  "drift_1109": {
+   "__class__": "Drift",
+   "length": 0.23999999999978172
+  },
+  "drift_1110": {
+   "__class__": "Drift",
+   "length": 0.5610000000001492
+  },
+  "drift_1111": {
+   "__class__": "Drift",
+   "length": 0.9169999999999163
+  },
+  "drift_1112": {
+   "__class__": "Drift",
+   "length": 0.6100000000001273
+  },
+  "drift_1113": {
+   "__class__": "Drift",
+   "length": 0.016000000000076398
+  },
+  "drift_1114": {
+   "__class__": "Drift",
+   "length": 0.18499999999994543
+  },
+  "drift_1115": {
+   "__class__": "Drift",
+   "length": 0.1950000000001637
+  },
+  "drift_1116": {
+   "__class__": "Drift",
+   "length": 0.12899999999945067
+  },
+  "drift_1117": {
+   "__class__": "Drift",
+   "length": 0.19499999999970896
+  },
+  "drift_1118": {
+   "__class__": "Drift",
+   "length": 0.1289999999999054
+  },
+  "drift_1119": {
+   "__class__": "Drift",
+   "length": 0.8539999999998145
+  },
+  "drift_1120": {
+   "__class__": "Drift",
+   "length": 0.8539999999998145
+  },
+  "drift_1121": {
+   "__class__": "Drift",
+   "length": 0.8540000000002692
+  },
+  "drift_1122": {
+   "__class__": "Drift",
+   "length": 0.1619999999998072
+  },
+  "drift_1123": {
+   "__class__": "Drift",
+   "length": 3.9406999999996515
+  },
+  "drift_1124": {
+   "__class__": "Drift",
+   "length": 0.6099999999996726
+  },
+  "drift_1125": {
+   "__class__": "Drift",
+   "length": 0.27999999999974534
+  },
+  "drift_1126": {
+   "__class__": "Drift",
+   "length": 0.22800000000006548
+  },
+  "drift_1127": {
+   "__class__": "Drift",
+   "length": 21.210700000000088
+  },
+  "drift_1128": {
+   "__class__": "Drift",
+   "length": 2.7325000000005275
+  },
+  "drift_1129": {
+   "__class__": "Drift",
+   "length": 0.14449999999987995
+  },
+  "drift_1130": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1131": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1132": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1133": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1134": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1135": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1136": {
+   "__class__": "Drift",
+   "length": 0.3700093099996593
+  },
+  "drift_1137": {
+   "__class__": "Drift",
+   "length": 0.3294999999998254
+  },
+  "drift_1138": {
+   "__class__": "Drift",
+   "length": 0.16820000000006985
+  },
+  "drift_1139": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1140": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1141": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1142": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1143": {
+   "__class__": "Drift",
+   "length": 0.6330093099995793
+  },
+  "drift_1144": {
+   "__class__": "Drift",
+   "length": 11.275699999999233
+  },
+  "drift_1145": {
+   "__class__": "Drift",
+   "length": 0.2618000000002212
+  },
+  "drift_1146": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_1147": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1148": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1149": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1150": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1151": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1152": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1153": {
+   "__class__": "Drift",
+   "length": 0.19600930999968114
+  },
+  "drift_1154": {
+   "__class__": "Drift",
+   "length": 0.16900000000077853
+  },
+  "drift_1155": {
+   "__class__": "Drift",
+   "length": 0.3686999999999898
+  },
+  "drift_1156": {
+   "__class__": "Drift",
+   "length": 0.09799999999995634
+  },
+  "drift_1157": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1158": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1159": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1160": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1161": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1162": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1163": {
+   "__class__": "Drift",
+   "length": 0.3190093100001832
+  },
+  "drift_1164": {
+   "__class__": "Drift",
+   "length": 0.09619999999995343
+  },
+  "drift_1165": {
+   "__class__": "Drift",
+   "length": 0.1375000000007276
+  },
+  "drift_1166": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1167": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1168": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1169": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1170": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1171": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1172": {
+   "__class__": "Drift",
+   "length": 1.1347093100002894
+  },
+  "drift_1173": {
+   "__class__": "Drift",
+   "length": 0.14699999999993452
+  },
+  "drift_1174": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1175": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1176": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1177": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1178": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1179": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1180": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_1181": {
+   "__class__": "Drift",
+   "length": 0.13870000000042637
+  },
+  "drift_1182": {
+   "__class__": "Drift",
+   "length": 0.13449999999920692
+  },
+  "drift_1183": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1184": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1185": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1186": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1187": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1188": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1189": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_1190": {
+   "__class__": "Drift",
+   "length": 0.15720000000055734
+  },
+  "drift_1191": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_1192": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1193": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1194": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1195": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1196": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1197": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1198": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_1199": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_1200": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1201": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1202": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1203": {
+   "__class__": "Drift",
+   "length": 0.40001934000065376
+  },
+  "drift_1204": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1205": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1206": {
+   "__class__": "Drift",
+   "length": 0.38900931000080163
+  },
+  "drift_1207": {
+   "__class__": "Drift",
+   "length": 0.7767000000003463
+  },
+  "drift_1208": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_1209": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1210": {
+   "__class__": "Drift",
+   "length": 0.3500100299988844
+  },
+  "drift_1211": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1212": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1213": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1214": {
+   "__class__": "Drift",
+   "length": 1.7077093099997
+  },
+  "drift_1215": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1216": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1217": {
+   "__class__": "Drift",
+   "length": 0.3600100300009217
+  },
+  "drift_1218": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1219": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1220": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1221": {
+   "__class__": "Drift",
+   "length": 0.19570930999998382
+  },
+  "drift_1222": {
+   "__class__": "Drift",
+   "length": 1.3369999999995343
+  },
+  "drift_1223": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1224": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1225": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1226": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1227": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1228": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1229": {
+   "__class__": "Drift",
+   "length": 1.1382093100010025
+  },
+  "drift_1230": {
+   "__class__": "Drift",
+   "length": 0.13449999999920692
+  },
+  "drift_1231": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1232": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1233": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1234": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1235": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1236": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1237": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_1238": {
+   "__class__": "Drift",
+   "length": 0.7322000000003754
+  },
+  "drift_1239": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1240": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1241": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1242": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1243": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1244": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1245": {
+   "__class__": "Drift",
+   "length": 1.7077093099997
+  },
+  "drift_1246": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1247": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1248": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1249": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1250": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1251": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1252": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_1253": {
+   "__class__": "Drift",
+   "length": 0.15719999999964784
+  },
+  "drift_1254": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_1255": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1256": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1257": {
+   "__class__": "Drift",
+   "length": 0.3500100299988844
+  },
+  "drift_1258": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1259": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1260": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1261": {
+   "__class__": "Drift",
+   "length": 1.138209310000093
+  },
+  "drift_1262": {
+   "__class__": "Drift",
+   "length": 0.13449999999920692
+  },
+  "drift_1263": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1264": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1265": {
+   "__class__": "Drift",
+   "length": 0.3600100300009217
+  },
+  "drift_1266": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1267": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1268": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1269": {
+   "__class__": "Drift",
+   "length": 0.19600931000059063
+  },
+  "drift_1270": {
+   "__class__": "Drift",
+   "length": 0.7617000000000189
+  },
+  "drift_1271": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_1272": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_1273": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1274": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1275": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1276": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1277": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1278": {
+   "__class__": "Drift",
+   "length": 0.3090093099999649
+  },
+  "drift_1279": {
+   "__class__": "Drift",
+   "length": 0.13119999999980791
+  },
+  "drift_1280": {
+   "__class__": "Drift",
+   "length": 0.1345000000010259
+  },
+  "drift_1281": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1282": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1283": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1284": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1285": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1286": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1287": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_1288": {
+   "__class__": "Drift",
+   "length": 0.15720000000055734
+  },
+  "drift_1289": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_1290": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1291": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1292": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1293": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1294": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1295": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1296": {
+   "__class__": "Drift",
+   "length": 0.3190093100001832
+  },
+  "drift_1297": {
+   "__class__": "Drift",
+   "length": 0.7326999999995678
+  },
+  "drift_1298": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1299": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1300": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1301": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1302": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1303": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1304": {
+   "__class__": "Drift",
+   "length": 1.7077093099997
+  },
+  "drift_1305": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1306": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1307": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1308": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1309": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1310": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1311": {
+   "__class__": "Drift",
+   "length": 0.3100093100001686
+  },
+  "drift_1312": {
+   "__class__": "Drift",
+   "length": 0.6576999999997497
+  },
+  "drift_1313": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1314": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1315": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1316": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1317": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1318": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1319": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_1320": {
+   "__class__": "Drift",
+   "length": 0.08019999999942229
+  },
+  "drift_1321": {
+   "__class__": "Drift",
+   "length": 0.47699999999986176
+  },
+  "drift_1322": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1323": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1324": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1325": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1326": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1327": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1328": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_1329": {
+   "__class__": "Drift",
+   "length": 0.13870000000042637
+  },
+  "drift_1330": {
+   "__class__": "Drift",
+   "length": 0.13449999999920692
+  },
+  "drift_1331": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1332": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1333": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1334": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1335": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1336": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1337": {
+   "__class__": "Drift",
+   "length": 1.7078093099999023
+  },
+  "drift_1338": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_1339": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1340": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1341": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1342": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1343": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1344": {
+   "__class__": "Drift",
+   "length": 1.7077093099997
+  },
+  "drift_1345": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1346": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1347": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1348": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1349": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1350": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1351": {
+   "__class__": "Drift",
+   "length": 1.1327093099989725
+  },
+  "drift_1352": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_1353": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1354": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1355": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1356": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1357": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1358": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1359": {
+   "__class__": "Drift",
+   "length": 1.1382093100010025
+  },
+  "drift_1360": {
+   "__class__": "Drift",
+   "length": 0.13449999999920692
+  },
+  "drift_1361": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1362": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1363": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1364": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1365": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1366": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1367": {
+   "__class__": "Drift",
+   "length": 0.19600930999968114
+  },
+  "drift_1368": {
+   "__class__": "Drift",
+   "length": 0.12269999999989523
+  },
+  "drift_1369": {
+   "__class__": "Drift",
+   "length": 0.12799999999970169
+  },
+  "drift_1370": {
+   "__class__": "Drift",
+   "length": 0.09799999999995634
+  },
+  "drift_1371": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1372": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1373": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1374": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1375": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1376": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1377": {
+   "__class__": "Drift",
+   "length": 0.3090093099999649
+  },
+  "drift_1378": {
+   "__class__": "Drift",
+   "length": 0.13319999999930587
+  },
+  "drift_1379": {
+   "__class__": "Drift",
+   "length": 0.13249999999970896
+  },
+  "drift_1380": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1381": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1382": {
+   "__class__": "Drift",
+   "length": 9.67200000000048
+  },
+  "drift_1383": {
+   "__class__": "Drift",
+   "length": 0.13699999999971624
+  },
+  "drift_1384": {
+   "__class__": "Drift",
+   "length": 0.2125000000005457
+  },
+  "drift_1385": {
+   "__class__": "Drift",
+   "length": 1.2665100300000631
+  },
+  "drift_1386": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1387": {
+   "__class__": "Drift",
+   "length": 0.49370931000066776
+  },
+  "drift_1388": {
+   "__class__": "Drift",
+   "length": 0.07899999999881402
+  },
+  "drift_1389": {
+   "__class__": "Drift",
+   "length": 0.147000000000844
+  },
+  "drift_1390": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_1391": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1392": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1393": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1394": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1395": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1396": {
+   "__class__": "Drift",
+   "length": 0.7160093100001177
+  },
+  "drift_1397": {
+   "__class__": "Drift",
+   "length": 0.3609999999998763
+  },
+  "drift_1398": {
+   "__class__": "Drift",
+   "length": 0.2167773600003784
+  },
+  "drift_1399": {
+   "__class__": "Drift",
+   "length": 0.25842264000038995
+  },
+  "drift_1400": {
+   "__class__": "Drift",
+   "length": 1.0335000000004584
+  },
+  "drift_1401": {
+   "__class__": "Drift",
+   "length": 1.4454999999998108
+  },
+  "drift_1402": {
+   "__class__": "Drift",
+   "length": 1.4454999999998108
+  },
+  "drift_1403": {
+   "__class__": "Drift",
+   "length": 0.3760000000002037
+  },
+  "drift_1404": {
+   "__class__": "Drift",
+   "length": 0.13699999999971624
+  },
+  "drift_1405": {
+   "__class__": "Drift",
+   "length": 0.13699999999971624
+  },
+  "drift_1406": {
+   "__class__": "Drift",
+   "length": 0.5000000000009095
+  },
+  "drift_1407": {
+   "__class__": "Drift",
+   "length": 5.981000000000677
+  },
+  "drift_1408": {
+   "__class__": "Drift",
+   "length": 1.6965000000000146
+  },
+  "drift_1409": {
+   "__class__": "Drift",
+   "length": 1.6965000000000146
+  },
+  "drift_1410": {
+   "__class__": "Drift",
+   "length": 0.4289999999991778
+  },
+  "drift_1411": {
+   "__class__": "Drift",
+   "length": 5.982999999999265
+  },
+  "drift_1412": {
+   "__class__": "Drift",
+   "length": 0.2180000000007567
+  },
+  "drift_1413": {
+   "__class__": "Drift",
+   "length": 0.1716999999998734
+  },
+  "drift_1414": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1415": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1416": {
+   "__class__": "Drift",
+   "length": 0.38400000000001455
+  },
+  "drift_1417": {
+   "__class__": "Drift",
+   "length": 0.29899999999997817
+  },
+  "drift_1418": {
+   "__class__": "Drift",
+   "length": 0.2180000000007567
+  },
+  "drift_1419": {
+   "__class__": "Drift",
+   "length": 0.7179999999989377
+  },
+  "drift_1420": {
+   "__class__": "Drift",
+   "length": 0.29899999999997817
+  },
+  "drift_1421": {
+   "__class__": "Drift",
+   "length": 0.29899999999997817
+  },
+  "drift_1422": {
+   "__class__": "Drift",
+   "length": 0.2179999999998472
+  },
+  "drift_1423": {
+   "__class__": "Drift",
+   "length": 6.3159999999998035
+  },
+  "drift_1424": {
+   "__class__": "Drift",
+   "length": 0.13699999999971624
+  },
+  "drift_1425": {
+   "__class__": "Drift",
+   "length": 1.1090000000012878
+  },
+  "drift_1426": {
+   "__class__": "Drift",
+   "length": 0.13699999999971624
+  },
+  "drift_1427": {
+   "__class__": "Drift",
+   "length": 0.13699999999971624
+  },
+  "drift_1428": {
+   "__class__": "Drift",
+   "length": 0.8334999999997308
+  },
+  "drift_1429": {
+   "__class__": "Drift",
+   "length": 0.5480000000006839
+  },
+  "drift_1430": {
+   "__class__": "Drift",
+   "length": 1.7672000000011394
+  },
+  "drift_1431": {
+   "__class__": "Drift",
+   "length": 1.167499999998654
+  },
+  "drift_1432": {
+   "__class__": "Drift",
+   "length": 0.07750000000123691
+  },
+  "drift_1433": {
+   "__class__": "Drift",
+   "length": 9.7475000000004
+  },
+  "drift_1434": {
+   "__class__": "Drift",
+   "length": 0.15999999999985448
+  },
+  "drift_1435": {
+   "__class__": "Drift",
+   "length": 3.355500000000575
+  },
+  "drift_1436": {
+   "__class__": "Drift",
+   "length": 2.5219999999999345
+  },
+  "drift_1437": {
+   "__class__": "Drift",
+   "length": 0.5999999999994543
+  },
+  "drift_1438": {
+   "__class__": "Drift",
+   "length": 0.6000000000003638
+  },
+  "drift_1439": {
+   "__class__": "Drift",
+   "length": 1.114699999999175
+  },
+  "drift_1440": {
+   "__class__": "Drift",
+   "length": 0.25600000000031287
+  },
+  "drift_1441": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1442": {
+   "__class__": "Drift",
+   "length": 0.17000000000007276
+  },
+  "drift_1443": {
+   "__class__": "Drift",
+   "length": 18.208999999999833
+  },
+  "drift_1444": {
+   "__class__": "Drift",
+   "length": 0.13700000000062573
+  },
+  "drift_1445": {
+   "__class__": "Drift",
+   "length": 2.335000000000946
+  },
+  "drift_1446": {
+   "__class__": "Drift",
+   "length": 0.1859999999996944
+  },
+  "drift_1447": {
+   "__class__": "Drift",
+   "length": 0.1390000000001237
+  },
+  "drift_1448": {
+   "__class__": "Drift",
+   "length": 0.11269999999967695
+  },
+  "drift_1449": {
+   "__class__": "Drift",
+   "length": 0.15349999999943975
+  },
+  "drift_1450": {
+   "__class__": "Drift",
+   "length": 0.1445000000003347
+  },
+  "drift_1451": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1452": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1453": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1454": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1455": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1456": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1457": {
+   "__class__": "Drift",
+   "length": 1.7077093099997
+  },
+  "drift_1458": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1459": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1460": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1461": {
+   "__class__": "Drift",
+   "length": 0.1660093099999358
+  },
+  "drift_1462": {
+   "__class__": "Drift",
+   "length": 0.2140100300002814
+  },
+  "drift_1463": {
+   "__class__": "Drift",
+   "length": 0.49600930999986304
+  },
+  "drift_1464": {
+   "__class__": "Drift",
+   "length": 6.5000000000009095
+  },
+  "drift_1465": {
+   "__class__": "Drift",
+   "length": 3.1039999999993597
+  },
+  "drift_1466": {
+   "__class__": "Drift",
+   "length": 1.1856999999990876
+  },
+  "drift_1467": {
+   "__class__": "Drift",
+   "length": 1.0850000000000364
+  },
+  "drift_1468": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1469": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1470": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1471": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1472": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1473": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1474": {
+   "__class__": "Drift",
+   "length": 0.19600930999877164
+  },
+  "drift_1475": {
+   "__class__": "Drift",
+   "length": 0.812700000001314
+  },
+  "drift_1476": {
+   "__class__": "Drift",
+   "length": 0.09799999999904685
+  },
+  "drift_1477": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1478": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1479": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1480": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1481": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1482": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1483": {
+   "__class__": "Drift",
+   "length": 0.31000930999925913
+  },
+  "drift_1484": {
+   "__class__": "Drift",
+   "length": 0.0882000000010521
+  },
+  "drift_1485": {
+   "__class__": "Drift",
+   "length": 0.13449999999920692
+  },
+  "drift_1486": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1487": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1488": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1489": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1490": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1491": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1492": {
+   "__class__": "Drift",
+   "length": 1.1347093100002894
+  },
+  "drift_1493": {
+   "__class__": "Drift",
+   "length": 0.14699999999902502
+  },
+  "drift_1494": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1495": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1496": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1497": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1498": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1499": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1500": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_1501": {
+   "__class__": "Drift",
+   "length": 0.13869999999951688
+  },
+  "drift_1502": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1503": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1504": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1505": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1506": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1507": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1508": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1509": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_1510": {
+   "__class__": "Drift",
+   "length": 0.15720000000055734
+  },
+  "drift_1511": {
+   "__class__": "Drift",
+   "length": 0.14899999999852298
+  },
+  "drift_1512": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1513": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1514": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1515": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1516": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1517": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1518": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_1519": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_1520": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1521": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1522": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1523": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1524": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1525": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1526": {
+   "__class__": "Drift",
+   "length": 0.38900930999989214
+  },
+  "drift_1527": {
+   "__class__": "Drift",
+   "length": 0.7766999999994368
+  },
+  "drift_1528": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1529": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1530": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1531": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1532": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1533": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1534": {
+   "__class__": "Drift",
+   "length": 0.29450931000064884
+  },
+  "drift_1535": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_1536": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1537": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1538": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1539": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1540": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1541": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1542": {
+   "__class__": "Drift",
+   "length": 1.055709309998747
+  },
+  "drift_1543": {
+   "__class__": "Drift",
+   "length": 0.47700000000077125
+  },
+  "drift_1544": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1545": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1546": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1547": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1548": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1549": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1550": {
+   "__class__": "Drift",
+   "length": 1.1382093099991835
+  },
+  "drift_1551": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1552": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1553": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1554": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1555": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1556": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1557": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1558": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_1559": {
+   "__class__": "Drift",
+   "length": 0.732199999999466
+  },
+  "drift_1560": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1561": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1562": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1563": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1564": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1565": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1566": {
+   "__class__": "Drift",
+   "length": 0.3090093099999649
+  },
+  "drift_1567": {
+   "__class__": "Drift",
+   "length": 0.700699999999415
+  },
+  "drift_1568": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1569": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1570": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1571": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1572": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1573": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1574": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_1575": {
+   "__class__": "Drift",
+   "length": 0.15719999999964784
+  },
+  "drift_1576": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_1577": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_1578": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1579": {
+   "__class__": "Drift",
+   "length": 0.3500100299988844
+  },
+  "drift_1580": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1581": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1582": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1583": {
+   "__class__": "Drift",
+   "length": 0.3190093099992737
+  },
+  "drift_1584": {
+   "__class__": "Drift",
+   "length": 0.1631999999999607
+  },
+  "drift_1585": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1586": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1587": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1588": {
+   "__class__": "Drift",
+   "length": 0.3600100300009217
+  },
+  "drift_1589": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1590": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1591": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1592": {
+   "__class__": "Drift",
+   "length": 0.4943093100000624
+  },
+  "drift_1593": {
+   "__class__": "Drift",
+   "length": 0.46339999999963766
+  },
+  "drift_1594": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_1595": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1596": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1597": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1598": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1599": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1600": {
+   "__class__": "Drift",
+   "length": 0.40001934000065376
+  },
+  "drift_1601": {
+   "__class__": "Drift",
+   "length": 1.1382093099991835
+  },
+  "drift_1602": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1603": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1604": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1605": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1606": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1607": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1608": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1609": {
+   "__class__": "Drift",
+   "length": 0.2990093099997466
+  },
+  "drift_1610": {
+   "__class__": "Drift",
+   "length": 0.1356999999989057
+  },
+  "drift_1611": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_1612": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1613": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1614": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1615": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1616": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1617": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1618": {
+   "__class__": "Drift",
+   "length": 0.3090093099999649
+  },
+  "drift_1619": {
+   "__class__": "Drift",
+   "length": 0.700699999999415
+  },
+  "drift_1620": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1621": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1622": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1623": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1624": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1625": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1626": {
+   "__class__": "Drift",
+   "length": 0.2990093099997466
+  },
+  "drift_1627": {
+   "__class__": "Drift",
+   "length": 0.7106999999996333
+  },
+  "drift_1628": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1629": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1630": {
+   "__class__": "Drift",
+   "length": 0.3500100299988844
+  },
+  "drift_1631": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1632": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1633": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1634": {
+   "__class__": "Drift",
+   "length": 0.3090093099999649
+  },
+  "drift_1635": {
+   "__class__": "Drift",
+   "length": 0.7007999999996173
+  },
+  "drift_1636": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1637": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1638": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1639": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1640": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1641": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1642": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_1643": {
+   "__class__": "Drift",
+   "length": 0.08020000000033178
+  },
+  "drift_1644": {
+   "__class__": "Drift",
+   "length": 0.47699999999895226
+  },
+  "drift_1645": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1646": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1647": {
+   "__class__": "Drift",
+   "length": 0.3500100299988844
+  },
+  "drift_1648": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1649": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1650": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1651": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_1652": {
+   "__class__": "Drift",
+   "length": 0.13869999999951688
+  },
+  "drift_1653": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1654": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1655": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1656": {
+   "__class__": "Drift",
+   "length": 0.3600100300009217
+  },
+  "drift_1657": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1658": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1659": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1660": {
+   "__class__": "Drift",
+   "length": 0.7037093099997946
+  },
+  "drift_1661": {
+   "__class__": "Drift",
+   "length": 0.7820000000001528
+  },
+  "drift_1662": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1663": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1664": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1665": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1666": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1667": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1668": {
+   "__class__": "Drift",
+   "length": 0.20600930999989941
+  },
+  "drift_1669": {
+   "__class__": "Drift",
+   "length": 0.6417000000001281
+  },
+  "drift_1670": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1671": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1672": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1673": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1674": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1675": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1676": {
+   "__class__": "Drift",
+   "length": 1.1327093099989725
+  },
+  "drift_1677": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_1678": {
+   "__class__": "Drift",
+   "length": 0.0319999999992433
+  },
+  "drift_1679": {
+   "__class__": "Drift",
+   "length": 0.11700000000109867
+  },
+  "drift_1680": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1681": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1682": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1683": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1684": {
+   "__class__": "Drift",
+   "length": 1.138209310000093
+  },
+  "drift_1685": {
+   "__class__": "Drift",
+   "length": 0.13449999999920692
+  },
+  "drift_1686": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1687": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1688": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1689": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1690": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1691": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1692": {
+   "__class__": "Drift",
+   "length": 0.19600930999968114
+  },
+  "drift_1693": {
+   "__class__": "Drift",
+   "length": 0.16899999999986903
+  },
+  "drift_1694": {
+   "__class__": "Drift",
+   "length": 0.3177000000005137
+  },
+  "drift_1695": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_1696": {
+   "__class__": "Drift",
+   "length": 0.032000000000152795
+  },
+  "drift_1697": {
+   "__class__": "Drift",
+   "length": 0.11700000000109867
+  },
+  "drift_1698": {
+   "__class__": "Drift",
+   "length": 0.3500100299988844
+  },
+  "drift_1699": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1700": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1701": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1702": {
+   "__class__": "Drift",
+   "length": 0.31100930999946286
+  },
+  "drift_1703": {
+   "__class__": "Drift",
+   "length": 0.11319999999977881
+  },
+  "drift_1704": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1705": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1706": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1707": {
+   "__class__": "Drift",
+   "length": 13.039999999999964
+  },
+  "drift_1708": {
+   "__class__": "Drift",
+   "length": 0.2960100300006161
+  },
+  "drift_1709": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1710": {
+   "__class__": "Drift",
+   "length": 0.5260093099996084
+  },
+  "drift_1711": {
+   "__class__": "Drift",
+   "length": 0.33369999999922584
+  },
+  "drift_1712": {
+   "__class__": "Drift",
+   "length": 0.147000000000844
+  },
+  "drift_1713": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1714": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1715": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1716": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1717": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1718": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1719": {
+   "__class__": "Drift",
+   "length": 1.7077093100006095
+  },
+  "drift_1720": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1721": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1722": {
+   "__class__": "Drift",
+   "length": 0.2779999999993379
+  },
+  "drift_1723": {
+   "__class__": "Drift",
+   "length": 0.08100000000104046
+  },
+  "drift_1724": {
+   "__class__": "Drift",
+   "length": 0.29899999999997817
+  },
+  "drift_1725": {
+   "__class__": "Drift",
+   "length": 0.29899999999997817
+  },
+  "drift_1726": {
+   "__class__": "Drift",
+   "length": 2.5299999999997453
+  },
+  "drift_1727": {
+   "__class__": "Drift",
+   "length": 0.3029999999989741
+  },
+  "drift_1728": {
+   "__class__": "Drift",
+   "length": 11.595000000000255
+  },
+  "drift_1729": {
+   "__class__": "Drift",
+   "length": 2.9646999999995387
+  },
+  "drift_1730": {
+   "__class__": "Drift",
+   "length": 0.1323000000002139
+  },
+  "drift_1731": {
+   "__class__": "Drift",
+   "length": 0.4677000000010594
+  },
+  "drift_1732": {
+   "__class__": "Drift",
+   "length": 0.24699999999847932
+  },
+  "drift_1733": {
+   "__class__": "Drift",
+   "length": 0.774000000000342
+  },
+  "drift_1734": {
+   "__class__": "Drift",
+   "length": 0.24380000000019209
+  },
+  "drift_1735": {
+   "__class__": "Drift",
+   "length": 1.2091999999993277
+  },
+  "drift_1736": {
+   "__class__": "Drift",
+   "length": 1.1825000000008004
+  },
+  "drift_1737": {
+   "__class__": "Drift",
+   "length": 1.251499999999396
+  },
+  "drift_1738": {
+   "__class__": "Drift",
+   "length": 0.774000000000342
+  },
+  "drift_1739": {
+   "__class__": "Drift",
+   "length": 0.9499999999998181
+  },
+  "drift_1740": {
+   "__class__": "Drift",
+   "length": 0.0029999999997016857
+  },
+  "drift_1741": {
+   "__class__": "Drift",
+   "length": 0.10019999999894935
+  },
+  "drift_1742": {
+   "__class__": "Drift",
+   "length": 0.10000000000127329
+  },
+  "drift_1743": {
+   "__class__": "Drift",
+   "length": 0.2617999999993117
+  },
+  "drift_1744": {
+   "__class__": "Drift",
+   "length": 0.16199999999935244
+  },
+  "drift_1745": {
+   "__class__": "Drift",
+   "length": 0.16200000000117143
+  },
+  "drift_1746": {
+   "__class__": "Drift",
+   "length": 0.16219999999975698
+  },
+  "drift_1747": {
+   "__class__": "Drift",
+   "length": 0.5297999999993408
+  },
+  "drift_1748": {
+   "__class__": "Drift",
+   "length": 0.22600000000147702
+  },
+  "drift_1749": {
+   "__class__": "Drift",
+   "length": 0.18999999999959982
+  },
+  "drift_1750": {
+   "__class__": "Drift",
+   "length": 0.3710000000010041
+  },
+  "drift_1751": {
+   "__class__": "Drift",
+   "length": 0.2935101200000645
+  },
+  "drift_1752": {
+   "__class__": "Drift",
+   "length": 0.013189880000027188
+  },
+  "drift_1753": {
+   "__class__": "Drift",
+   "length": 0.6099999999996726
+  },
+  "drift_1754": {
+   "__class__": "Drift",
+   "length": 0.16199999999935244
+  },
+  "drift_1755": {
+   "__class__": "Drift",
+   "length": 0.16200000000117143
+  },
+  "drift_1756": {
+   "__class__": "Drift",
+   "length": 0.16199999999935244
+  },
+  "drift_1757": {
+   "__class__": "Drift",
+   "length": 0.16200000000117143
+  },
+  "drift_1758": {
+   "__class__": "Drift",
+   "length": 0.16199999999935244
+  },
+  "drift_1759": {
+   "__class__": "Drift",
+   "length": 0.16199999999935244
+  },
+  "drift_1760": {
+   "__class__": "Drift",
+   "length": 0.16200000000117143
+  },
+  "drift_1761": {
+   "__class__": "Drift",
+   "length": 0.16199999999935244
+  },
+  "drift_1762": {
+   "__class__": "Drift",
+   "length": 0.16199999999935244
+  },
+  "drift_1763": {
+   "__class__": "Drift",
+   "length": 0.16200000000117143
+  },
+  "drift_1764": {
+   "__class__": "Drift",
+   "length": 0.35970000000179425
+  },
+  "drift_1765": {
+   "__class__": "Drift",
+   "length": 1.1249999999990905
+  },
+  "drift_1766": {
+   "__class__": "Drift",
+   "length": 6.877300000000105
+  },
+  "drift_1767": {
+   "__class__": "Drift",
+   "length": 1.1096999999999753
+  },
+  "drift_1768": {
+   "__class__": "Drift",
+   "length": 0.2719999999999345
+  },
+  "drift_1769": {
+   "__class__": "Drift",
+   "length": 0.30899999999928696
+  },
+  "drift_1770": {
+   "__class__": "Drift",
+   "length": 9.846000000000458
+  },
+  "drift_1771": {
+   "__class__": "Drift",
+   "length": 12.265300000000025
+  },
+  "drift_1772": {
+   "__class__": "Drift",
+   "length": 1.4348999999992884
+  },
+  "drift_1773": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1774": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1775": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1776": {
+   "__class__": "Drift",
+   "length": 0.3600100300009217
+  },
+  "drift_1777": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1778": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1779": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1780": {
+   "__class__": "Drift",
+   "length": 0.5400093100006416
+  },
+  "drift_1781": {
+   "__class__": "Drift",
+   "length": 0.8927000000003318
+  },
+  "drift_1782": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_1783": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1784": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1785": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1786": {
+   "__class__": "Drift",
+   "length": 12.588409309999406
+  },
+  "drift_1787": {
+   "__class__": "Drift",
+   "length": 0.3021000000007916
+  },
+  "drift_1788": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_1789": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1790": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1791": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1792": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1793": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1794": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1795": {
+   "__class__": "Drift",
+   "length": 0.19600930999877164
+  },
+  "drift_1796": {
+   "__class__": "Drift",
+   "length": 0.15500000000065484
+  },
+  "drift_1797": {
+   "__class__": "Drift",
+   "length": 0.33370000000013533
+  },
+  "drift_1798": {
+   "__class__": "Drift",
+   "length": 0.14699999999993452
+  },
+  "drift_1799": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1800": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1801": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1802": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1803": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1804": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1805": {
+   "__class__": "Drift",
+   "length": 0.3100093100001686
+  },
+  "drift_1806": {
+   "__class__": "Drift",
+   "length": 0.08820000000014261
+  },
+  "drift_1807": {
+   "__class__": "Drift",
+   "length": 0.13449999999920692
+  },
+  "drift_1808": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1809": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1810": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1811": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1812": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1813": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1814": {
+   "__class__": "Drift",
+   "length": 1.132709309999882
+  },
+  "drift_1815": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_1816": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1817": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1818": {
+   "__class__": "Drift",
+   "length": 0.3500100299988844
+  },
+  "drift_1819": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1820": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1821": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1822": {
+   "__class__": "Drift",
+   "length": 0.29450930999973934
+  },
+  "drift_1823": {
+   "__class__": "Drift",
+   "length": 0.13869999999951688
+  },
+  "drift_1824": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1825": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1826": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1827": {
+   "__class__": "Drift",
+   "length": 0.3600100300009217
+  },
+  "drift_1828": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1829": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1830": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1831": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_1832": {
+   "__class__": "Drift",
+   "length": 0.15720000000055734
+  },
+  "drift_1833": {
+   "__class__": "Drift",
+   "length": 0.14899999999943248
+  },
+  "drift_1834": {
+   "__class__": "Drift",
+   "length": 0.014999999999417923
+  },
+  "drift_1835": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1836": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1837": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1838": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1839": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1840": {
+   "__class__": "Drift",
+   "length": 0.29450931000064884
+  },
+  "drift_1841": {
+   "__class__": "Drift",
+   "length": 0.7082000000000335
+  },
+  "drift_1842": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1843": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1844": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1845": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1846": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1847": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1848": {
+   "__class__": "Drift",
+   "length": 0.38900930999989214
+  },
+  "drift_1849": {
+   "__class__": "Drift",
+   "length": 0.7766999999994368
+  },
+  "drift_1850": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1851": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1852": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1853": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1854": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1855": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1856": {
+   "__class__": "Drift",
+   "length": 0.3190093099992737
+  },
+  "drift_1857": {
+   "__class__": "Drift",
+   "length": 0.6487000000006446
+  },
+  "drift_1858": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1859": {
+   "__class__": "Drift",
+   "length": 0.09500000000116415
+  },
+  "drift_1860": {
+   "__class__": "Drift",
+   "length": 0.3600100299991027
+  },
+  "drift_1861": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1862": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1863": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1864": {
+   "__class__": "Drift",
+   "length": 1.055709310000566
+  },
+  "drift_1865": {
+   "__class__": "Drift",
+   "length": 0.47699999999895226
+  },
+  "drift_1866": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1867": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1868": {
+   "__class__": "Drift",
+   "length": 0.3500100300007034
+  },
+  "drift_1869": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1870": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1871": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1872": {
+   "__class__": "Drift",
+   "length": 1.1382093099991835
+  },
+  "drift_1873": {
+   "__class__": "Drift",
+   "length": 0.13450000000011642
+  },
+  "drift_1874": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1875": {
+   "__class__": "Drift",
+   "length": 0.09499999999934516
+  },
+  "drift_1876": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1877": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1878": {
+   "__class__": "Drift",
+   "length": 0.3900193400004355
+  },
+  "drift_1879": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1880": {
+   "__class__": "Drift",
+   "length": 0.29850931000055425
+  },
+  "drift_1881": {
+   "__class__": "Drift",
+   "length": 0.732199999999466
+  },
+  "drift_1882": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1883": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1884": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1885": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1886": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1887": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1888": {
+   "__class__": "Drift",
+   "length": 1.7077093099997
+  },
+  "drift_1889": {
+   "__class__": "Drift",
+   "length": 0.025000000000545697
+  },
+  "drift_1890": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1891": {
+   "__class__": "Drift",
+   "length": 0.3600100300000122
+  },
+  "drift_1892": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1893": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1894": {
+   "__class__": "Drift",
+   "length": 0.3800193400002172
+  },
+  "drift_1895": {
+   "__class__": "Drift",
+   "length": 0.29850930999964476
+  },
+  "drift_1896": {
+   "__class__": "Drift",
+   "length": 0.15719999999964784
+  },
+  "drift_1897": {
+   "__class__": "Drift",
+   "length": 0.14900000000034197
+  },
+  "drift_1898": {
+   "__class__": "Drift",
+   "length": 0.015000000000327418
+  },
+  "drift_1899": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  },
+  "drift_1900": {
+   "__class__": "Drift",
+   "length": 0.3500100299997939
+  },
+  "drift_1901": {
+   "__class__": "Drift",
+   "length": 0.3800193399993077
+  },
+  "drift_1902": {
+   "__class__": "Drift",
+   "length": 0.390019339999526
+  },
+  "drift_1903": {
+   "__class__": "Drift",
+   "length": 0.40001933999974426
+  },
+  "drift_1904": {
+   "__class__": "Drift",
+   "length": 0.3190093100001832
+  },
+  "drift_1905": {
+   "__class__": "Drift",
+   "length": 0.08119999999962602
+  },
+  "drift_1906": {
+   "__class__": "Drift",
+   "length": 0.13250000000061846
+  },
+  "drift_1907": {
+   "__class__": "Drift",
+   "length": 0.024999999999636202
+  },
+  "drift_1908": {
+   "__class__": "Drift",
+   "length": 0.09500000000025466
+  }
+ },
+ "_var_management_data": {
+  "var_values": {
+   "t_turn_s": 0.0,
+   "__vary_default": {},
+   "pi": 3.141592653589793,
+   "twopi": 6.283185307179586,
+   "degrad": 57.29577951308232,
+   "raddeg": 0.017453292519943295,
+   "e": 2.718281828459045,
+   "emass": 0.00051099895,
+   "pmass": 0.93827208816,
+   "nmass": 0.93956542052,
+   "umass": 0.93149410242,
+   "mumass": 0.1056583715,
+   "clight": 299792458.0,
+   "qelect": 1.602176634e-19,
+   "hbar": 6.582119569e-25,
+   "erad": 2.8179403262e-15,
+   "prad": 5.174168663504975e-12,
+   "kmba": 0.008445141542,
+   "kmbb": 0.008445141542,
+   "kqf": 0.01157926643000353,
+   "klsda": -0.10791912465451854,
+   "kmdv10107": 0,
+   "kqd": -0.01158101412515668,
+   "klsfb": 0.06464580696074636,
+   "kmdh10207": 0,
+   "klod10302": 0,
+   "klsdb": -0.05989435299384773,
+   "kmdv10307": 0,
+   "kloe10402": 0,
+   "kmdh10407": 0,
+   "kmdv10507": 0,
+   "klse10602": 0.0,
+   "kmdh10607": 0,
+   "klod": 0,
+   "kmdv10707": 0,
+   "klof": 0,
+   "klsfa": 0.04982277106309112,
+   "kmdh10807": 0,
+   "kmdv10907": 0,
+   "kmdh11007": 0,
+   "kmdv11107": 0,
+   "kmdh11207": 0,
+   "kmdv11307": 0,
+   "kqe11402": 0,
+   "kmdh11407": 0,
+   "kmdv11507": 0,
+   "kmdh11607": 0,
+   "kqms": 0,
+   "kmkqh11653": 0,
+   "kmkqv11679": 0,
+   "kmdv11705": 0,
+   "kmdh11831": 0,
+   "kmdva11904": 0,
+   "kqda": -0.009475375193310012,
+   "kmkpa11931": 0,
+   "kmkpa11936": 0,
+   "kmkpc11952": 0,
+   "kmdsh11971": 0,
+   "kloe12002": 0,
+   "kmdh12007": 0,
+   "kmdv12107": 0,
+   "kmdh12207": 0,
+   "kmdv12307": 0,
+   "klse12402": 0,
+   "kmdh12407": 0,
+   "kmdv12507": 0,
+   "kmdh12607": 0,
+   "kmdv12707": 0,
+   "kmdh12807": 0,
+   "klqsa": 0,
+   "kmdv12907": 0,
+   "kloen13002": 0,
+   "kmdh13007": 0,
+   "kmdv13107": 0,
+   "kmdh13207": 0,
+   "kmdv13307": 0,
+   "kmdh13407": 0,
+   "kmdv13507": 0,
+   "kloe13602": 0,
+   "kmdh13607": 0,
+   "kmdv20107": 0,
+   "kmdh20207": 0,
+   "klod20302": 0,
+   "kmdv20307": 0,
+   "kmdh20407": 0,
+   "kmdv20507": 0,
+   "klse20602": 0,
+   "kmdh20607": 0,
+   "kmdv20707": 0,
+   "kmdh20807": 0,
+   "kmdv20907": 0,
+   "kmdh21007": 0,
+   "kmdv21107": 0,
+   "kmpsh21202": 0,
+   "kmdh21207": 0,
+   "kmpsv21303": 0,
+   "kmdv21307": 0,
+   "kmdh21407": 0,
+   "kmplh21431": 0,
+   "kmpsv21503": 0,
+   "kmdv21507": 0,
+   "kmdha21606": 0,
+   "kqfa": 0.00947394526091198,
+   "kmdva21703": 0,
+   "kmpnh21732": 0,
+   "kmst217": 0,
+   "kmdha21804": 0,
+   "kmse218": 0,
+   "kmdva21932": 0,
+   "kzkha21991": 0,
+   "kzkv21993": 0,
+   "kmplh21995": 0,
+   "kloe22002": 0,
+   "kmdh22007": 0,
+   "kmpsv22103": 0,
+   "kmdv22107": 0,
+   "kmplh22195": 0,
+   "kmdh22207": 0,
+   "kmpsv22303": 0,
+   "kmdv22307": 0,
+   "klse22402": 0.0,
+   "kmdh22407": 0,
+   "kmdv22507": 0,
+   "kmdh22607": 0,
+   "kmdv22707": 0,
+   "kmdh22807": 0,
+   "kmdv22907": 0,
+   "kloen23002": 0,
+   "kmdh23007": 0,
+   "kmdv23107": 0,
+   "kmdh23207": 0,
+   "kmdv23307": 0,
+   "kmdh23407": 0,
+   "kmdv23507": 0,
+   "kloen23602": 0,
+   "kmdh23607": 0,
+   "kmdv30107": 0,
+   "kqe30202": 0,
+   "kmdh30207": 0,
+   "kmdv30307": 0,
+   "kmdh30407": 0,
+   "kmdv30507": 0,
+   "kqecd30602": 0,
+   "kmdh30607": 0,
+   "kmdv30707": 0,
+   "kmdh30807": 0,
+   "kmdv30907": 0,
+   "kmdh31007": 0,
+   "kmdv31107": 0,
+   "kmdh31207": 0,
+   "kmdv31307": 0,
+   "kqecd31402": 0,
+   "kmdh31407": 0,
+   "kmdv31507": 0,
+   "kmdh31607": 0,
+   "kmdv31707": 0,
+   "vacl31733": 0,
+   "kmdh31807": 0,
+   "kmdv31907": 0,
+   "kloe32002": 0,
+   "kmdh32007": 0,
+   "kmdv32107": 0,
+   "kmdh32207": 0,
+   "kmdv32307": 0,
+   "klse32402": 0,
+   "kmdh32407": 0,
+   "kmdv32507": 0,
+   "kmdh32607": 0,
+   "kmdv32707": 0,
+   "kmdh32807": 0,
+   "kmdv32907": 0,
+   "kloe33002": 0,
+   "kmdh33007": 0,
+   "kmdv33107": 0,
+   "klsfc": 0.04982277106309112,
+   "kmdh33207": 0,
+   "kmdv33307": 0,
+   "kmdh33407": 0,
+   "kmdv33507": 0,
+   "kloe33602": 0,
+   "kmdh33607": 0,
+   "kmdv40107": 0,
+   "kmdh40207": 0,
+   "klod40302": 0,
+   "kmdv40307": 0,
+   "kloe40402": 0,
+   "kmdh40407": 0,
+   "kmdv40507": 0,
+   "klse40602": 0.0,
+   "kmdh40607": 0,
+   "kmdv40707": 0,
+   "kmdh40807": 0,
+   "kmdv40907": 0,
+   "kmdh41007": 0,
+   "kmdv41107": 0,
+   "kmdh41207": 0,
+   "kmpsv41303": 0,
+   "kmdv41307": 0,
+   "kmpsh41402": 0,
+   "kmdh41407": 0,
+   "kmplv41501": 0,
+   "kmdv41507": 0,
+   "kmdh41607": 0,
+   "kmke41631": 0,
+   "kmke41634": 0,
+   "kmke41637": 0,
+   "kmke41651": 0,
+   "kmplh41658": 0,
+   "kmdva41703": 0,
+   "kmdha41804": 0,
+   "kmse418": 0,
+   "kmdva41932": 0,
+   "kmplh41994": 0,
+   "kmdh42007": 0,
+   "kmplv42101": 0,
+   "kmdv42107": 0,
+   "kmpsh42198": 0,
+   "kmdh42207": 0,
+   "kmpsv42303": 0,
+   "kmdv42307": 0,
+   "klsen42402": 0,
+   "kmdh42407": 0,
+   "kmdv42507": 0,
+   "kmdh42607": 0,
+   "kmdv42707": 0,
+   "kmdh42807": 0,
+   "kmdv42907": 0,
+   "kmdh43007": 0,
+   "kmdv43107": 0,
+   "kmdh43207": 0,
+   "kmdv43307": 0,
+   "kmdh43407": 0,
+   "kmdv43507": 0,
+   "kmdh43607": 0,
+   "kmdv50107": 0,
+   "kqe50202": 0,
+   "kmdh50207": 0,
+   "klod50302": 0,
+   "kmdv50307": 0,
+   "kloen50402": 0,
+   "kmdh50407": 0,
+   "kmdv50507": 0,
+   "klse50602": 0,
+   "kmdh50607": 0,
+   "kmdv50707": 0,
+   "kmdh50807": 0,
+   "kmdv50907": 0,
+   "kmdh51007": 0,
+   "kmdv51107": 0,
+   "kmdh51207": 0,
+   "kmdv51307": 0,
+   "kqe51402": 0,
+   "kmdh51407": 0,
+   "kmdv51507": 0,
+   "kmdhw51637": 0,
+   "kmdv51707": 0,
+   "kmdhd51832": 0,
+   "kmdv51920": 0,
+   "kloen52002": 0,
+   "kmdh52007": 0,
+   "kmdv52107": 0,
+   "kmdh52207": 0,
+   "kmdv52307": 0,
+   "klse52402": 0.0,
+   "kmdh52407": 0,
+   "kmdv52507": 0,
+   "kmdh52607": 0,
+   "kmdv52707": 0,
+   "kmdh52807": 0,
+   "kmdv52907": 0,
+   "kmdh53007": 0,
+   "kmdv53107": 0,
+   "kmdh53207": 0,
+   "kmdv53307": 0,
+   "kqecd53402": 0,
+   "kmdh53407": 0,
+   "kmdv53507": 0,
+   "kloen53602": 0,
+   "kmdh53607": 0,
+   "kmdv60107": 0,
+   "kmdh60207": 0,
+   "kqe60302": 0,
+   "kmdv60307": 0,
+   "kqe60402": 0,
+   "kmdh60407": 0,
+   "kqe60502": 0,
+   "kmdv60507": 0,
+   "kqe60602": 0,
+   "kmdh60607": 0,
+   "kmdv60707": 0,
+   "kmdh60807": 0,
+   "kmdv60907": 0,
+   "kmdh61007": 0,
+   "kmdv61107": 0,
+   "kmdh61207": 0,
+   "kmpsv61303": 0,
+   "kmdv61307": 0,
+   "kmpsh61402": 0,
+   "kmdh61407": 0,
+   "kmpsv61503": 0,
+   "kmdv61507": 0,
+   "kmdh61607": 0,
+   "kmke61631": 0,
+   "kmke61634": 0,
+   "kmke61637": 0,
+   "kmplh61655": 0,
+   "kmdva61703": 0,
+   "kmst617": 0,
+   "kmse618": 0,
+   "kmdva61932": 0,
+   "kmplh61996": 0,
+   "kmdh62007": 0,
+   "kmpsv62103": 0,
+   "kmdv62107": 0,
+   "kmpsh62199": 0,
+   "kmdh62207": 0,
+   "kmpsv62303": 0,
+   "kmdv62307": 0,
+   "klse62402": 0,
+   "kmdh62407": 0,
+   "kmdv62507": 0,
+   "kmdh62607": 0,
+   "kmdv62707": 0,
+   "kmdh62807": 0,
+   "kmdv62907": 0,
+   "kloe63002": 0,
+   "kmdh63007": 0,
+   "kmdv63107": 0,
+   "kmdh63207": 0,
+   "kmdv63307": 0,
+   "kmdh63407": 0,
+   "kmdv63507": 0,
+   "kloe63602": 0,
+   "kmdh63607": 0,
+   "qx0": 20.13,
+   "qy0": 20.18,
+   "kqd0": -0.01158101412515668,
+   "qh_setvalue": 20.13,
+   "dkqd_h": -0.0001167644785878596,
+   "qv_setvalue": 20.18,
+   "dkqd_v": -0.0003918448750990765,
+   "kqf0": 0.01157926643000353,
+   "dkqf_h": 0.0003910514166916948,
+   "dkqf_v": 0.0001171072522694149,
+   "klsda0": -0.08038230681545866,
+   "logical.lsdaqph": 0.0003652519197294077,
+   "qph_setvalue": 0.5,
+   "logical.lsdaqpv": -0.05543888759784918,
+   "qpv_setvalue": 0.5,
+   "klsdb0": -0.03780512404085105,
+   "logical.lsdbqph": -0.0201425735344012,
+   "logical.lsdbqpv": -0.02403588437159217,
+   "klsfa0": 0.03125797253170887,
+   "logical.lsfaqph": 0.039524517589292,
+   "logical.lsfaqpv": -0.002394920526527511,
+   "klsfb0": 0.05021892309013845,
+   "logical.lsfbqph": 0.001786268777066228,
+   "logical.lsfbqpv": 0.0270674989641496,
+   "klsfc0": 0.03125797253170887,
+   "logical.lsfcqph": 0.039524517589292,
+   "logical.lsfcqpv": -0.002394920526527511,
+   "freq200": 200264500.0,
+   "volt200": 4500000.0,
+   "lag200": 180,
+   "freq800": 801058000.0,
+   "volt800": 500000.0,
+   "lag800": 180
+  },
+  "functions": {
+   "_funcs": {}
+  }
+ },
+ "_var_manager": [
+  [
+   "element_refs['qf.10010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.10030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.10070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.10105'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.10107'].ksl[0]",
+   "vars['kmdv10107']"
+  ],
+  [
+   "element_refs['qd.10110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.10130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.10170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.10205'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.10207'].knl[0]",
+   "(-vars['kmdh10207'])"
+  ],
+  [
+   "element_refs['qf.10210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.10230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.10270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.10302'].k3",
+   "vars['klod10302']"
+  ],
+  [
+   "element_refs['lsd.10305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.10307'].ksl[0]",
+   "vars['kmdv10307']"
+  ],
+  [
+   "element_refs['qd.10310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.10330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.10370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loe.10402'].k3",
+   "vars['kloe10402']"
+  ],
+  [
+   "element_refs['mdh.10407'].knl[0]",
+   "(-vars['kmdh10407'])"
+  ],
+  [
+   "element_refs['qf.10410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.10430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.10470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.10507'].ksl[0]",
+   "vars['kmdv10507']"
+  ],
+  [
+   "element_refs['qd.10510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.10530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.10570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.10602'].k2",
+   "vars['klse10602']"
+  ],
+  [
+   "element_refs['mdh.10607'].knl[0]",
+   "(-vars['kmdh10607'])"
+  ],
+  [
+   "element_refs['qf.10610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.10630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.10670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.10702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.10707'].ksl[0]",
+   "vars['kmdv10707']"
+  ],
+  [
+   "element_refs['qd.10710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.10730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.10770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.10802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['lsf.10805'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.10807'].knl[0]",
+   "(-vars['kmdh10807'])"
+  ],
+  [
+   "element_refs['qf.10810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.10830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.10870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.10907'].ksl[0]",
+   "vars['kmdv10907']"
+  ],
+  [
+   "element_refs['qd.10910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.10930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.10950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.10970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.10990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.11007'].knl[0]",
+   "(-vars['kmdh11007'])"
+  ],
+  [
+   "element_refs['qf.11010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.11030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.11050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.11070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.11090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.11105'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.11107'].ksl[0]",
+   "vars['kmdv11107']"
+  ],
+  [
+   "element_refs['qd.11110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.11130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.11150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.11170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.11190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.11205'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.11207'].knl[0]",
+   "(-vars['kmdh11207'])"
+  ],
+  [
+   "element_refs['qf.11210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.11230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.11250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.11270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.11290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.11305'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.11307'].ksl[0]",
+   "vars['kmdv11307']"
+  ],
+  [
+   "element_refs['qd.11310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.11330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.11350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.11370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.11390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qe.11402'].k1",
+   "vars['kqe11402']"
+  ],
+  [
+   "element_refs['lsf.11405'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.11407'].knl[0]",
+   "(-vars['kmdh11407'])"
+  ],
+  [
+   "element_refs['qf.11410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mbb.11470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.11490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.11505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.11507'].ksl[0]",
+   "vars['kmdv11507']"
+  ],
+  [
+   "element_refs['qd.11510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.11530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.11550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.11570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.11590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.11607'].knl[0]",
+   "(-vars['kmdh11607'])"
+  ],
+  [
+   "element_refs['qf.11610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['qms.11631'].k1",
+   "vars['kqms']"
+  ],
+  [
+   "element_refs['qms.11632'].k1",
+   "vars['kqms']"
+  ],
+  [
+   "element_refs['qms.11634'].k1",
+   "vars['kqms']"
+  ],
+  [
+   "element_refs['qms.11635'].k1",
+   "vars['kqms']"
+  ],
+  [
+   "element_refs['mkqh.11653'].knl[0]",
+   "(-vars['kmkqh11653'])"
+  ],
+  [
+   "element_refs['mkqv.11679'].ksl[0]",
+   "vars['kmkqv11679']"
+  ],
+  [
+   "element_refs['mdv.11705'].ksl[0]",
+   "vars['kmdv11705']"
+  ],
+  [
+   "element_refs['qd.11710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['qf.11810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mdh.11820'].knl[0]",
+   "(-vars['kmdh11831'])"
+  ],
+  [
+   "element_refs['mdva.11904'].ksl[0]",
+   "vars['kmdva11904']"
+  ],
+  [
+   "element_refs['qda.11910'].k1",
+   "vars['kqda']"
+  ],
+  [
+   "element_refs['mkpa.11931'].knl[0]",
+   "(-vars['kmkpa11931'])"
+  ],
+  [
+   "element_refs['mkpa.11936'].knl[0]",
+   "(-vars['kmkpa11936'])"
+  ],
+  [
+   "element_refs['mkpc.11952'].knl[0]",
+   "(-vars['kmkpc11952'])"
+  ],
+  [
+   "element_refs['mdsh.11971'].knl[0]",
+   "(-vars['kmdsh11971'])"
+  ],
+  [
+   "element_refs['loe.12002'].k3",
+   "vars['kloe12002']"
+  ],
+  [
+   "element_refs['lsf.12005'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.12007'].knl[0]",
+   "(-vars['kmdh12007'])"
+  ],
+  [
+   "element_refs['qf.12010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.12030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.12070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.12107'].ksl[0]",
+   "vars['kmdv12107']"
+  ],
+  [
+   "element_refs['qd.12110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.12130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lof.12202'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.12207'].knl[0]",
+   "(-vars['kmdh12207'])"
+  ],
+  [
+   "element_refs['qf.12210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.12230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.12270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.12305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.12307'].ksl[0]",
+   "vars['kmdv12307']"
+  ],
+  [
+   "element_refs['qd.12310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.12330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.12370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.12402'].k2",
+   "vars['klse12402']"
+  ],
+  [
+   "element_refs['lsf.12405'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.12407'].knl[0]",
+   "(-vars['kmdh12407'])"
+  ],
+  [
+   "element_refs['qf.12410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.12430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.12470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.12505'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.12507'].ksl[0]",
+   "vars['kmdv12507']"
+  ],
+  [
+   "element_refs['qd.12510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.12530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.12570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.12602'].k3",
+   "(-vars['klof'])"
+  ],
+  [
+   "element_refs['lsf.12605'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.12607'].knl[0]",
+   "(-vars['kmdh12607'])"
+  ],
+  [
+   "element_refs['qf.12610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.12630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.12670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.12702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['lsd.12705'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.12707'].ksl[0]",
+   "vars['kmdv12707']"
+  ],
+  [
+   "element_refs['qd.12710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.12730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.12770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.12802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.12807'].knl[0]",
+   "(-vars['kmdh12807'])"
+  ],
+  [
+   "element_refs['qf.12810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.12830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.12870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lqsa.12902'].k1s",
+   "vars['klqsa']"
+  ],
+  [
+   "element_refs['mdv.12907'].ksl[0]",
+   "vars['kmdv12907']"
+  ],
+  [
+   "element_refs['qd.12910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.12930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.12950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.12970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.12990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loen.13002'].k3",
+   "vars['kloen13002']"
+  ],
+  [
+   "element_refs['mdh.13007'].knl[0]",
+   "(-vars['kmdh13007'])"
+  ],
+  [
+   "element_refs['qf.13010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.13030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.13050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.13070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.13090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.13107'].ksl[0]",
+   "vars['kmdv13107']"
+  ],
+  [
+   "element_refs['qd.13110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.13130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.13150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.13170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.13190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.13205'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.13207'].knl[0]",
+   "(-vars['kmdh13207'])"
+  ],
+  [
+   "element_refs['qf.13210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.13230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.13250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.13270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.13290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.13302'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.13307'].ksl[0]",
+   "vars['kmdv13307']"
+  ],
+  [
+   "element_refs['qd.13310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.13330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.13350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.13370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.13390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.13407'].knl[0]",
+   "(-vars['kmdh13407'])"
+  ],
+  [
+   "element_refs['qf.13410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.13430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.13450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.13470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.13490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.13502'].k3",
+   "(-vars['klod'])"
+  ],
+  [
+   "element_refs['lsd.13505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.13507'].ksl[0]",
+   "vars['kmdv13507']"
+  ],
+  [
+   "element_refs['qd.13510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.13530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.13550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.13570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.13590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loe.13602'].k3",
+   "vars['kloe13602']"
+  ],
+  [
+   "element_refs['lsf.13605'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.13607'].knl[0]",
+   "(-vars['kmdh13607'])"
+  ],
+  [
+   "element_refs['qf.20010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.20030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.20070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.20105'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.20107'].ksl[0]",
+   "vars['kmdv20107']"
+  ],
+  [
+   "element_refs['qd.20110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.20130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.20170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.20205'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.20207'].knl[0]",
+   "(-vars['kmdh20207'])"
+  ],
+  [
+   "element_refs['qf.20210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.20230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.20270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.20302'].k3",
+   "vars['klod20302']"
+  ],
+  [
+   "element_refs['lsd.20305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.20307'].ksl[0]",
+   "vars['kmdv20307']"
+  ],
+  [
+   "element_refs['qd.20310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.20330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.20370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.20407'].knl[0]",
+   "(-vars['kmdh20407'])"
+  ],
+  [
+   "element_refs['qf.20410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.20430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.20470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.20507'].ksl[0]",
+   "vars['kmdv20507']"
+  ],
+  [
+   "element_refs['qd.20510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.20530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.20570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.20602'].k2",
+   "vars['klse20602']"
+  ],
+  [
+   "element_refs['mdh.20607'].knl[0]",
+   "(-vars['kmdh20607'])"
+  ],
+  [
+   "element_refs['qf.20610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.20630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.20670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.20702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.20707'].ksl[0]",
+   "vars['kmdv20707']"
+  ],
+  [
+   "element_refs['qd.20710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.20730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.20770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.20802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['lsf.20805'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.20807'].knl[0]",
+   "(-vars['kmdh20807'])"
+  ],
+  [
+   "element_refs['qf.20810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.20830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.20870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.20907'].ksl[0]",
+   "vars['kmdv20907']"
+  ],
+  [
+   "element_refs['qd.20910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.20930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.20950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.20970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.20990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.21007'].knl[0]",
+   "(-vars['kmdh21007'])"
+  ],
+  [
+   "element_refs['qf.21010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.21030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.21050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.21070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.21090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.21105'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.21107'].ksl[0]",
+   "vars['kmdv21107']"
+  ],
+  [
+   "element_refs['qd.21110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.21130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.21150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.21170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.21190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mpsh.21202'].knl[0]",
+   "(-vars['kmpsh21202'])"
+  ],
+  [
+   "element_refs['lsf.21205'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.21207'].knl[0]",
+   "(-vars['kmdh21207'])"
+  ],
+  [
+   "element_refs['qf.21210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.21230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.21250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.21270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.21290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.21303'].ksl[0]",
+   "vars['kmpsv21303']"
+  ],
+  [
+   "element_refs['lsd.21305'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.21307'].ksl[0]",
+   "vars['kmdv21307']"
+  ],
+  [
+   "element_refs['qd.21310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.21330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.21350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.21370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.21390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.21405'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.21407'].knl[0]",
+   "(-vars['kmdh21407'])"
+  ],
+  [
+   "element_refs['qf.21410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mplh.21431'].knl[0]",
+   "(-vars['kmplh21431'])"
+  ],
+  [
+   "element_refs['mbb.21470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.21490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.21503'].ksl[0]",
+   "vars['kmpsv21503']"
+  ],
+  [
+   "element_refs['lsd.21505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.21507'].ksl[0]",
+   "vars['kmdv21507']"
+  ],
+  [
+   "element_refs['qd.21510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.21530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.21550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.21570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.21590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdha.21606'].knl[0]",
+   "(-vars['kmdha21606'])"
+  ],
+  [
+   "element_refs['qfa.21610'].k1",
+   "vars['kqfa']"
+  ],
+  [
+   "element_refs['mdva.21703'].ksl[0]",
+   "vars['kmdva21703']"
+  ],
+  [
+   "element_refs['qda.21710'].k1",
+   "vars['kqda']"
+  ],
+  [
+   "element_refs['mpnh.21732'].knl[0]",
+   "(-vars['kmpnh21732'])"
+  ],
+  [
+   "element_refs['mst.21774'].knl[0]",
+   "(-vars['kmst217'])"
+  ],
+  [
+   "element_refs['mst.21779'].knl[0]",
+   "(-vars['kmst217'])"
+  ],
+  [
+   "element_refs['mst.21794'].knl[0]",
+   "(-vars['kmst217'])"
+  ],
+  [
+   "element_refs['mdha.21806'].knl[0]",
+   "(-vars['kmdha21804'])"
+  ],
+  [
+   "element_refs['qfa.21810'].k1",
+   "vars['kqfa']"
+  ],
+  [
+   "element_refs['mse.21832'].knl[0]",
+   "(-vars['kmse218'])"
+  ],
+  [
+   "element_refs['mse.21837'].knl[0]",
+   "(-vars['kmse218'])"
+  ],
+  [
+   "element_refs['mse.21852'].knl[0]",
+   "(-vars['kmse218'])"
+  ],
+  [
+   "element_refs['mse.21857'].knl[0]",
+   "(-vars['kmse218'])"
+  ],
+  [
+   "element_refs['mse.21872'].knl[0]",
+   "(-vars['kmse218'])"
+  ],
+  [
+   "element_refs['qda.21910'].k1",
+   "vars['kqda']"
+  ],
+  [
+   "element_refs['mdva.21932'].ksl[0]",
+   "vars['kmdva21932']"
+  ],
+  [
+   "element_refs['zkha.21991'].knl[0]",
+   "(-vars['kzkha21991'])"
+  ],
+  [
+   "element_refs['zkv.21993'].ksl[0]",
+   "vars['kzkv21993']"
+  ],
+  [
+   "element_refs['mplh.21995'].knl[0]",
+   "(-vars['kmplh21995'])"
+  ],
+  [
+   "element_refs['loe.22002'].k3",
+   "vars['kloe22002']"
+  ],
+  [
+   "element_refs['lsf.22005'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.22007'].knl[0]",
+   "(-vars['kmdh22007'])"
+  ],
+  [
+   "element_refs['qf.22010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.22030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.22070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.22103'].ksl[0]",
+   "vars['kmpsv22103']"
+  ],
+  [
+   "element_refs['mdv.22107'].ksl[0]",
+   "vars['kmdv22107']"
+  ],
+  [
+   "element_refs['qd.22110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.22130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mplh.22195'].knl[0]",
+   "(-vars['kmplh22195'])"
+  ],
+  [
+   "element_refs['lof.22202'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.22207'].knl[0]",
+   "(-vars['kmdh22207'])"
+  ],
+  [
+   "element_refs['qf.22210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.22230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.22270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.22303'].ksl[0]",
+   "vars['kmpsv22303']"
+  ],
+  [
+   "element_refs['lsd.22305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.22307'].ksl[0]",
+   "vars['kmdv22307']"
+  ],
+  [
+   "element_refs['qd.22310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.22330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.22370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.22402'].k2",
+   "vars['klse22402']"
+  ],
+  [
+   "element_refs['lsf.22405'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.22407'].knl[0]",
+   "(-vars['kmdh22407'])"
+  ],
+  [
+   "element_refs['qf.22410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.22430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.22470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.22505'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.22507'].ksl[0]",
+   "vars['kmdv22507']"
+  ],
+  [
+   "element_refs['qd.22510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.22530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.22570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.22602'].k3",
+   "(-vars['klof'])"
+  ],
+  [
+   "element_refs['lsf.22605'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.22607'].knl[0]",
+   "(-vars['kmdh22607'])"
+  ],
+  [
+   "element_refs['qf.22610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.22630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.22670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.22702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['lsd.22705'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.22707'].ksl[0]",
+   "vars['kmdv22707']"
+  ],
+  [
+   "element_refs['qd.22710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.22730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.22770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.22802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.22807'].knl[0]",
+   "(-vars['kmdh22807'])"
+  ],
+  [
+   "element_refs['qf.22810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.22830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.22870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lqsa.22902'].k1s",
+   "vars['klqsa']"
+  ],
+  [
+   "element_refs['mdv.22907'].ksl[0]",
+   "vars['kmdv22907']"
+  ],
+  [
+   "element_refs['qd.22910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.22930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.22950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.22970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.22990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loen.23002'].k3",
+   "vars['kloen23002']"
+  ],
+  [
+   "element_refs['mdh.23007'].knl[0]",
+   "(-vars['kmdh23007'])"
+  ],
+  [
+   "element_refs['qf.23010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.23030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.23050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.23070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.23090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.23107'].ksl[0]",
+   "vars['kmdv23107']"
+  ],
+  [
+   "element_refs['qd.23110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.23130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.23150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.23170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.23190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.23205'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.23207'].knl[0]",
+   "(-vars['kmdh23207'])"
+  ],
+  [
+   "element_refs['qf.23210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.23230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.23250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.23270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.23290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.23302'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.23307'].ksl[0]",
+   "vars['kmdv23307']"
+  ],
+  [
+   "element_refs['qd.23310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.23330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.23350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.23370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.23390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.23407'].knl[0]",
+   "(-vars['kmdh23407'])"
+  ],
+  [
+   "element_refs['qf.23410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.23430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.23450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.23470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.23490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.23502'].k3",
+   "(-vars['klod'])"
+  ],
+  [
+   "element_refs['lsd.23505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.23507'].ksl[0]",
+   "vars['kmdv23507']"
+  ],
+  [
+   "element_refs['qd.23510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.23530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.23550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.23570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.23590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loen.23602'].k3",
+   "vars['kloen23602']"
+  ],
+  [
+   "element_refs['lsf.23605'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.23607'].knl[0]",
+   "(-vars['kmdh23607'])"
+  ],
+  [
+   "element_refs['qf.30010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.30030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.30070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.30105'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.30107'].ksl[0]",
+   "vars['kmdv30107']"
+  ],
+  [
+   "element_refs['qd.30110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.30130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.30170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qe.30202'].k1",
+   "vars['kqe30202']"
+  ],
+  [
+   "element_refs['lsf.30205'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.30207'].knl[0]",
+   "(-vars['kmdh30207'])"
+  ],
+  [
+   "element_refs['qf.30210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.30230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.30270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.30305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.30307'].ksl[0]",
+   "vars['kmdv30307']"
+  ],
+  [
+   "element_refs['qd.30310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.30330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.30370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.30407'].knl[0]",
+   "(-vars['kmdh30407'])"
+  ],
+  [
+   "element_refs['qf.30410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.30430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.30470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.30507'].ksl[0]",
+   "vars['kmdv30507']"
+  ],
+  [
+   "element_refs['qd.30510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.30530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.30570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qecd.30602'].k1",
+   "vars['kqecd30602']"
+  ],
+  [
+   "element_refs['mdh.30607'].knl[0]",
+   "(-vars['kmdh30607'])"
+  ],
+  [
+   "element_refs['qf.30610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.30630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.30670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.30702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.30707'].ksl[0]",
+   "vars['kmdv30707']"
+  ],
+  [
+   "element_refs['qd.30710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.30730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.30770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.30802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['lsf.30805'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.30807'].knl[0]",
+   "(-vars['kmdh30807'])"
+  ],
+  [
+   "element_refs['qf.30810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.30830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.30870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.30907'].ksl[0]",
+   "vars['kmdv30907']"
+  ],
+  [
+   "element_refs['qd.30910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.30930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.30950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.30970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.30990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.31007'].knl[0]",
+   "(-vars['kmdh31007'])"
+  ],
+  [
+   "element_refs['qf.31010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.31030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.31050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.31070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.31090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.31105'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.31107'].ksl[0]",
+   "vars['kmdv31107']"
+  ],
+  [
+   "element_refs['qd.31110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.31130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.31150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.31170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.31190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.31205'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.31207'].knl[0]",
+   "(-vars['kmdh31207'])"
+  ],
+  [
+   "element_refs['qf.31210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.31230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.31250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.31270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.31290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.31305'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.31307'].ksl[0]",
+   "vars['kmdv31307']"
+  ],
+  [
+   "element_refs['qd.31310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.31330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.31350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.31370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.31390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qecd.31402'].k1",
+   "vars['kqecd31402']"
+  ],
+  [
+   "element_refs['lsf.31405'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.31407'].knl[0]",
+   "(-vars['kmdh31407'])"
+  ],
+  [
+   "element_refs['qf.31410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mbb.31470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.31490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.31505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.31507'].ksl[0]",
+   "vars['kmdv31507']"
+  ],
+  [
+   "element_refs['qd.31510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.31530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.31550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.31570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.31590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.31607'].knl[0]",
+   "(-vars['kmdh31607'])"
+  ],
+  [
+   "element_refs['qf.31610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mdv.31707'].ksl[0]",
+   "vars['kmdv31707']"
+  ],
+  [
+   "element_refs['qd.31710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mdh.31807'].knl[0]",
+   "(-vars['kmdh31807'])"
+  ],
+  [
+   "element_refs['qf.31810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mdv.31907'].ksl[0]",
+   "vars['kmdv31907']"
+  ],
+  [
+   "element_refs['qd.31910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['loe.32002'].k3",
+   "vars['kloe32002']"
+  ],
+  [
+   "element_refs['lsf.32005'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.32007'].knl[0]",
+   "(-vars['kmdh32007'])"
+  ],
+  [
+   "element_refs['qf.32010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.32030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.32070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.32107'].ksl[0]",
+   "vars['kmdv32107']"
+  ],
+  [
+   "element_refs['qd.32110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.32130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lof.32202'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.32207'].knl[0]",
+   "(-vars['kmdh32207'])"
+  ],
+  [
+   "element_refs['qf.32210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.32230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.32270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.32305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.32307'].ksl[0]",
+   "vars['kmdv32307']"
+  ],
+  [
+   "element_refs['qd.32310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.32330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.32370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.32402'].k2",
+   "vars['klse32402']"
+  ],
+  [
+   "element_refs['lsf.32405'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.32407'].knl[0]",
+   "(-vars['kmdh32407'])"
+  ],
+  [
+   "element_refs['qf.32410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.32430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.32470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.32505'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.32507'].ksl[0]",
+   "vars['kmdv32507']"
+  ],
+  [
+   "element_refs['qd.32510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.32530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.32570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.32602'].k3",
+   "(-vars['klof'])"
+  ],
+  [
+   "element_refs['lsf.32605'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.32607'].knl[0]",
+   "(-vars['kmdh32607'])"
+  ],
+  [
+   "element_refs['qf.32610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.32630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.32670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.32702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['lsd.32705'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.32707'].ksl[0]",
+   "vars['kmdv32707']"
+  ],
+  [
+   "element_refs['qd.32710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.32730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.32770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.32802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.32807'].knl[0]",
+   "(-vars['kmdh32807'])"
+  ],
+  [
+   "element_refs['qf.32810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.32830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.32870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lqsa.32902'].k1s",
+   "vars['klqsa']"
+  ],
+  [
+   "element_refs['mdv.32907'].ksl[0]",
+   "vars['kmdv32907']"
+  ],
+  [
+   "element_refs['qd.32910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.32930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.32950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.32970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.32990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loe.33002'].k3",
+   "vars['kloe33002']"
+  ],
+  [
+   "element_refs['mdh.33007'].knl[0]",
+   "(-vars['kmdh33007'])"
+  ],
+  [
+   "element_refs['qf.33010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.33030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.33050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.33070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.33090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.33107'].ksl[0]",
+   "vars['kmdv33107']"
+  ],
+  [
+   "element_refs['qd.33110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.33130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.33150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.33170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.33190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.33205'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.33207'].knl[0]",
+   "(-vars['kmdh33207'])"
+  ],
+  [
+   "element_refs['qf.33210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.33230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.33250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.33270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.33290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.33302'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.33307'].ksl[0]",
+   "vars['kmdv33307']"
+  ],
+  [
+   "element_refs['qd.33310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.33330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.33350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.33370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.33390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.33407'].knl[0]",
+   "(-vars['kmdh33407'])"
+  ],
+  [
+   "element_refs['qf.33410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.33430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.33450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.33470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.33490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.33502'].k3",
+   "(-vars['klod'])"
+  ],
+  [
+   "element_refs['lsd.33505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.33507'].ksl[0]",
+   "vars['kmdv33507']"
+  ],
+  [
+   "element_refs['qd.33510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.33530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.33550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.33570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.33590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loe.33602'].k3",
+   "vars['kloe33602']"
+  ],
+  [
+   "element_refs['lsf.33605'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.33607'].knl[0]",
+   "(-vars['kmdh33607'])"
+  ],
+  [
+   "element_refs['qf.40010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.40030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.40070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.40105'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.40107'].ksl[0]",
+   "vars['kmdv40107']"
+  ],
+  [
+   "element_refs['qd.40110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.40130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.40170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.40205'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.40207'].knl[0]",
+   "(-vars['kmdh40207'])"
+  ],
+  [
+   "element_refs['qf.40210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.40230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.40270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.40302'].k3",
+   "vars['klod40302']"
+  ],
+  [
+   "element_refs['lsd.40305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.40307'].ksl[0]",
+   "vars['kmdv40307']"
+  ],
+  [
+   "element_refs['qd.40310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.40330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.40370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loe.40402'].k3",
+   "vars['kloe40402']"
+  ],
+  [
+   "element_refs['mdh.40407'].knl[0]",
+   "(-vars['kmdh40407'])"
+  ],
+  [
+   "element_refs['qf.40410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.40430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.40470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.40507'].ksl[0]",
+   "vars['kmdv40507']"
+  ],
+  [
+   "element_refs['qd.40510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.40530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.40570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.40602'].k2",
+   "vars['klse40602']"
+  ],
+  [
+   "element_refs['mdh.40607'].knl[0]",
+   "(-vars['kmdh40607'])"
+  ],
+  [
+   "element_refs['qf.40610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.40630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.40670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.40702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.40707'].ksl[0]",
+   "vars['kmdv40707']"
+  ],
+  [
+   "element_refs['qd.40710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.40730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.40770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.40802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['lsf.40805'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.40807'].knl[0]",
+   "(-vars['kmdh40807'])"
+  ],
+  [
+   "element_refs['qf.40810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.40830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.40870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.40907'].ksl[0]",
+   "vars['kmdv40907']"
+  ],
+  [
+   "element_refs['qd.40910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.40930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.40950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.40970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.40990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.41007'].knl[0]",
+   "(-vars['kmdh41007'])"
+  ],
+  [
+   "element_refs['qf.41010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.41030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.41050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.41070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.41090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.41105'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.41107'].ksl[0]",
+   "vars['kmdv41107']"
+  ],
+  [
+   "element_refs['qd.41110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.41130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.41150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.41170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.41190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.41205'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.41207'].knl[0]",
+   "(-vars['kmdh41207'])"
+  ],
+  [
+   "element_refs['qf.41210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.41230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.41250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.41270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.41290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.41303'].ksl[0]",
+   "vars['kmpsv41303']"
+  ],
+  [
+   "element_refs['lsd.41305'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.41307'].ksl[0]",
+   "vars['kmdv41307']"
+  ],
+  [
+   "element_refs['qd.41310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.41330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.41350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.41370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.41390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mpsh.41402'].knl[0]",
+   "(-vars['kmpsh41402'])"
+  ],
+  [
+   "element_refs['lsf.41405'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.41407'].knl[0]",
+   "(-vars['kmdh41407'])"
+  ],
+  [
+   "element_refs['qf.41410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mbb.41470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.41490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mplv.41501'].ksl[0]",
+   "vars['kmplv41501']"
+  ],
+  [
+   "element_refs['lsd.41505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.41507'].ksl[0]",
+   "vars['kmdv41507']"
+  ],
+  [
+   "element_refs['qd.41510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.41530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.41550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.41570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.41590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.41607'].knl[0]",
+   "(-vars['kmdh41607'])"
+  ],
+  [
+   "element_refs['qf.41610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mke.41631'].knl[0]",
+   "(-vars['kmke41631'])"
+  ],
+  [
+   "element_refs['mke.41634'].knl[0]",
+   "(-vars['kmke41634'])"
+  ],
+  [
+   "element_refs['mke.41637'].knl[0]",
+   "(-vars['kmke41637'])"
+  ],
+  [
+   "element_refs['mke.41651'].knl[0]",
+   "(-vars['kmke41651'])"
+  ],
+  [
+   "element_refs['mplh.41658'].knl[0]",
+   "(-vars['kmplh41658'])"
+  ],
+  [
+   "element_refs['mdva.41703'].ksl[0]",
+   "vars['kmdva41703']"
+  ],
+  [
+   "element_refs['qda.41710'].k1",
+   "vars['kqda']"
+  ],
+  [
+   "element_refs['mdha.41804'].knl[0]",
+   "(-vars['kmdha41804'])"
+  ],
+  [
+   "element_refs['qfa.41810'].k1",
+   "vars['kqfa']"
+  ],
+  [
+   "element_refs['mse.41837'].knl[0]",
+   "(-vars['kmse418'])"
+  ],
+  [
+   "element_refs['mse.41852'].knl[0]",
+   "(-vars['kmse418'])"
+  ],
+  [
+   "element_refs['mse.41856'].knl[0]",
+   "(-vars['kmse418'])"
+  ],
+  [
+   "element_refs['mse.41871'].knl[0]",
+   "(-vars['kmse418'])"
+  ],
+  [
+   "element_refs['mse.41876'].knl[0]",
+   "(-vars['kmse418'])"
+  ],
+  [
+   "element_refs['mse.41891'].knl[0]",
+   "(-vars['kmse418'])"
+  ],
+  [
+   "element_refs['qda.41910'].k1",
+   "vars['kqda']"
+  ],
+  [
+   "element_refs['mdva.41932'].ksl[0]",
+   "vars['kmdva41932']"
+  ],
+  [
+   "element_refs['mplh.41994'].knl[0]",
+   "(-vars['kmplh41994'])"
+  ],
+  [
+   "element_refs['lsf.42005'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.42007'].knl[0]",
+   "(-vars['kmdh42007'])"
+  ],
+  [
+   "element_refs['qf.42010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.42030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.42070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mplv.42101'].ksl[0]",
+   "vars['kmplv42101']"
+  ],
+  [
+   "element_refs['mdv.42107'].ksl[0]",
+   "vars['kmdv42107']"
+  ],
+  [
+   "element_refs['qd.42110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.42130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsh.42198'].knl[0]",
+   "(-vars['kmpsh42198'])"
+  ],
+  [
+   "element_refs['lof.42202'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.42207'].knl[0]",
+   "(-vars['kmdh42207'])"
+  ],
+  [
+   "element_refs['qf.42210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.42230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.42270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.42303'].ksl[0]",
+   "vars['kmpsv42303']"
+  ],
+  [
+   "element_refs['lsd.42305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.42307'].ksl[0]",
+   "vars['kmdv42307']"
+  ],
+  [
+   "element_refs['qd.42310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.42330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.42370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsen.42402'].k2",
+   "vars['klsen42402']"
+  ],
+  [
+   "element_refs['lsf.42405'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.42407'].knl[0]",
+   "(-vars['kmdh42407'])"
+  ],
+  [
+   "element_refs['qf.42410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.42430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.42470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.42505'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.42507'].ksl[0]",
+   "vars['kmdv42507']"
+  ],
+  [
+   "element_refs['qd.42510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.42530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.42570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.42602'].k3",
+   "(-vars['klof'])"
+  ],
+  [
+   "element_refs['lsf.42605'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.42607'].knl[0]",
+   "(-vars['kmdh42607'])"
+  ],
+  [
+   "element_refs['qf.42610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.42630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.42670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.42702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['lsd.42705'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.42707'].ksl[0]",
+   "vars['kmdv42707']"
+  ],
+  [
+   "element_refs['qd.42710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.42730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.42770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.42802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.42807'].knl[0]",
+   "(-vars['kmdh42807'])"
+  ],
+  [
+   "element_refs['qf.42810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.42830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.42870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lqsa.42902'].k1s",
+   "vars['klqsa']"
+  ],
+  [
+   "element_refs['mdv.42907'].ksl[0]",
+   "vars['kmdv42907']"
+  ],
+  [
+   "element_refs['qd.42910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.42930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.42950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.42970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.42990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.43007'].knl[0]",
+   "(-vars['kmdh43007'])"
+  ],
+  [
+   "element_refs['qf.43010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.43030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.43050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.43070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.43090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.43107'].ksl[0]",
+   "vars['kmdv43107']"
+  ],
+  [
+   "element_refs['qd.43110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.43130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.43150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.43170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.43190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.43205'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.43207'].knl[0]",
+   "(-vars['kmdh43207'])"
+  ],
+  [
+   "element_refs['qf.43210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.43230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.43250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.43270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.43290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.43302'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.43307'].ksl[0]",
+   "vars['kmdv43307']"
+  ],
+  [
+   "element_refs['qd.43310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.43330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.43350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.43370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.43390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.43407'].knl[0]",
+   "(-vars['kmdh43407'])"
+  ],
+  [
+   "element_refs['qf.43410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.43430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.43450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.43470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.43490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.43502'].k3",
+   "(-vars['klod'])"
+  ],
+  [
+   "element_refs['lsd.43505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.43507'].ksl[0]",
+   "vars['kmdv43507']"
+  ],
+  [
+   "element_refs['qd.43510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.43530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.43550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.43570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.43590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.43605'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.43607'].knl[0]",
+   "(-vars['kmdh43607'])"
+  ],
+  [
+   "element_refs['qf.50010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.50030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.50070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.50105'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.50107'].ksl[0]",
+   "vars['kmdv50107']"
+  ],
+  [
+   "element_refs['qd.50110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.50130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.50170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qe.50202'].k1",
+   "vars['kqe50202']"
+  ],
+  [
+   "element_refs['lsf.50205'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.50207'].knl[0]",
+   "(-vars['kmdh50207'])"
+  ],
+  [
+   "element_refs['qf.50210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.50230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.50270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.50302'].k3",
+   "vars['klod50302']"
+  ],
+  [
+   "element_refs['lsd.50305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.50307'].ksl[0]",
+   "vars['kmdv50307']"
+  ],
+  [
+   "element_refs['qd.50310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.50330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.50370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loen.50402'].k3",
+   "vars['kloen50402']"
+  ],
+  [
+   "element_refs['mdh.50407'].knl[0]",
+   "(-vars['kmdh50407'])"
+  ],
+  [
+   "element_refs['qf.50410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.50430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.50470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.50507'].ksl[0]",
+   "vars['kmdv50507']"
+  ],
+  [
+   "element_refs['qd.50510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.50530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.50570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.50602'].k2",
+   "vars['klse50602']"
+  ],
+  [
+   "element_refs['mdh.50607'].knl[0]",
+   "(-vars['kmdh50607'])"
+  ],
+  [
+   "element_refs['qf.50610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.50630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.50670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.50702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.50707'].ksl[0]",
+   "vars['kmdv50707']"
+  ],
+  [
+   "element_refs['qd.50710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.50730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.50770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.50802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['lsf.50805'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.50807'].knl[0]",
+   "(-vars['kmdh50807'])"
+  ],
+  [
+   "element_refs['qf.50810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.50830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.50870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.50907'].ksl[0]",
+   "vars['kmdv50907']"
+  ],
+  [
+   "element_refs['qd.50910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.50930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.50950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.50970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.50990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.51007'].knl[0]",
+   "(-vars['kmdh51007'])"
+  ],
+  [
+   "element_refs['qf.51010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.51030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.51050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.51070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.51090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.51105'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.51107'].ksl[0]",
+   "vars['kmdv51107']"
+  ],
+  [
+   "element_refs['qd.51110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.51130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.51150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.51170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.51190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.51205'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.51207'].knl[0]",
+   "(-vars['kmdh51207'])"
+  ],
+  [
+   "element_refs['qf.51210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.51230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.51250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.51270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.51290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.51305'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.51307'].ksl[0]",
+   "vars['kmdv51307']"
+  ],
+  [
+   "element_refs['qd.51310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.51330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.51350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.51370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.51390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qe.51402'].k1",
+   "vars['kqe51402']"
+  ],
+  [
+   "element_refs['lsf.51405'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.51407'].knl[0]",
+   "(-vars['kmdh51407'])"
+  ],
+  [
+   "element_refs['qf.51410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mbb.51470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.51490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.51505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.51507'].ksl[0]",
+   "vars['kmdv51507']"
+  ],
+  [
+   "element_refs['qd.51510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.51530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.51550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.51570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.51590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qfa.51610'].k1",
+   "vars['kqfa']"
+  ],
+  [
+   "element_refs['mdhw.51637'].knl[0]",
+   "(-vars['kmdhw51637'])"
+  ],
+  [
+   "element_refs['mdv.51707'].ksl[0]",
+   "vars['kmdv51707']"
+  ],
+  [
+   "element_refs['qd.51710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['qfa.51810'].k1",
+   "vars['kqfa']"
+  ],
+  [
+   "element_refs['mdhd.51832'].knl[0]",
+   "(-vars['kmdhd51832'])"
+  ],
+  [
+   "element_refs['qd.51910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mdv.51920'].ksl[0]",
+   "vars['kmdv51920']"
+  ],
+  [
+   "element_refs['loen.52002'].k3",
+   "vars['kloen52002']"
+  ],
+  [
+   "element_refs['lsf.52005'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.52007'].knl[0]",
+   "(-vars['kmdh52007'])"
+  ],
+  [
+   "element_refs['qf.52010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.52030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.52070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.52107'].ksl[0]",
+   "vars['kmdv52107']"
+  ],
+  [
+   "element_refs['qd.52110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.52130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdh.52207'].knl[0]",
+   "(-vars['kmdh52207'])"
+  ],
+  [
+   "element_refs['qf.52210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.52230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.52270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.52305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.52307'].ksl[0]",
+   "vars['kmdv52307']"
+  ],
+  [
+   "element_refs['qd.52310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.52330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.52370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.52402'].k2",
+   "vars['klse52402']"
+  ],
+  [
+   "element_refs['lsf.52405'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.52407'].knl[0]",
+   "(-vars['kmdh52407'])"
+  ],
+  [
+   "element_refs['qf.52410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.52430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.52470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.52505'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.52507'].ksl[0]",
+   "vars['kmdv52507']"
+  ],
+  [
+   "element_refs['qd.52510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.52530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.52570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.52602'].k3",
+   "(-vars['klof'])"
+  ],
+  [
+   "element_refs['lsf.52605'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.52607'].knl[0]",
+   "(-vars['kmdh52607'])"
+  ],
+  [
+   "element_refs['qf.52610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.52630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.52670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.52702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['lsd.52705'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.52707'].ksl[0]",
+   "vars['kmdv52707']"
+  ],
+  [
+   "element_refs['qd.52710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.52730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.52770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.52802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.52807'].knl[0]",
+   "(-vars['kmdh52807'])"
+  ],
+  [
+   "element_refs['qf.52810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.52830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.52870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lqsa.52902'].k1s",
+   "vars['klqsa']"
+  ],
+  [
+   "element_refs['mdv.52907'].ksl[0]",
+   "vars['kmdv52907']"
+  ],
+  [
+   "element_refs['qd.52910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.52930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.52950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.52970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.52990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.53002'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.53007'].knl[0]",
+   "(-vars['kmdh53007'])"
+  ],
+  [
+   "element_refs['qf.53010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.53030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.53050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.53070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.53090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.53107'].ksl[0]",
+   "vars['kmdv53107']"
+  ],
+  [
+   "element_refs['qd.53110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.53130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.53150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.53170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.53190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.53205'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.53207'].knl[0]",
+   "(-vars['kmdh53207'])"
+  ],
+  [
+   "element_refs['qf.53210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.53230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.53250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.53270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.53290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.53302'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.53307'].ksl[0]",
+   "vars['kmdv53307']"
+  ],
+  [
+   "element_refs['qd.53310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.53330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.53350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.53370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.53390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qecd.53402'].k1",
+   "vars['kqecd53402']"
+  ],
+  [
+   "element_refs['mdh.53407'].knl[0]",
+   "(-vars['kmdh53407'])"
+  ],
+  [
+   "element_refs['qf.53410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.53430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.53450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.53470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.53490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.53502'].k3",
+   "(-vars['klod'])"
+  ],
+  [
+   "element_refs['lsd.53505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.53507'].ksl[0]",
+   "vars['kmdv53507']"
+  ],
+  [
+   "element_refs['qd.53510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.53530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.53550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.53570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.53590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loen.53602'].k3",
+   "vars['kloen53602']"
+  ],
+  [
+   "element_refs['lsf.53605'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.53607'].knl[0]",
+   "(-vars['kmdh53607'])"
+  ],
+  [
+   "element_refs['qf.60010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.60030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.60070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.60105'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.60107'].ksl[0]",
+   "vars['kmdv60107']"
+  ],
+  [
+   "element_refs['qd.60110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.60130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.60170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.60205'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.60207'].knl[0]",
+   "(-vars['kmdh60207'])"
+  ],
+  [
+   "element_refs['qf.60210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.60230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.60270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['qe.60302'].k1",
+   "vars['kqe60302']"
+  ],
+  [
+   "element_refs['lsd.60305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.60307'].ksl[0]",
+   "vars['kmdv60307']"
+  ],
+  [
+   "element_refs['qd.60310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.60330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.60370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qe.60402'].k1",
+   "vars['kqe60402']"
+  ],
+  [
+   "element_refs['mdh.60407'].knl[0]",
+   "(-vars['kmdh60407'])"
+  ],
+  [
+   "element_refs['qf.60410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.60430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.60470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['qe.60502'].k1",
+   "vars['kqe60502']"
+  ],
+  [
+   "element_refs['mdv.60507'].ksl[0]",
+   "vars['kmdv60507']"
+  ],
+  [
+   "element_refs['qd.60510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.60530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.60570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['qe.60602'].k1",
+   "vars['kqe60602']"
+  ],
+  [
+   "element_refs['mdh.60607'].knl[0]",
+   "(-vars['kmdh60607'])"
+  ],
+  [
+   "element_refs['qf.60610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.60630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.60670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.60702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.60707'].ksl[0]",
+   "vars['kmdv60707']"
+  ],
+  [
+   "element_refs['qd.60710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.60730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.60770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.60802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['lsf.60805'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.60807'].knl[0]",
+   "(-vars['kmdh60807'])"
+  ],
+  [
+   "element_refs['qf.60810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.60830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.60870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.60907'].ksl[0]",
+   "vars['kmdv60907']"
+  ],
+  [
+   "element_refs['qd.60910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.60930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.60950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.60970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.60990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.61007'].knl[0]",
+   "(-vars['kmdh61007'])"
+  ],
+  [
+   "element_refs['qf.61010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.61030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.61050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.61070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.61090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.61105'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.61107'].ksl[0]",
+   "vars['kmdv61107']"
+  ],
+  [
+   "element_refs['qd.61110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.61130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.61150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.61170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.61190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.61205'].k2",
+   "vars['klsfc']"
+  ],
+  [
+   "element_refs['mdh.61207'].knl[0]",
+   "(-vars['kmdh61207'])"
+  ],
+  [
+   "element_refs['qf.61210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.61230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.61250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.61270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.61290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.61303'].ksl[0]",
+   "vars['kmpsv61303']"
+  ],
+  [
+   "element_refs['lsd.61305'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.61307'].ksl[0]",
+   "vars['kmdv61307']"
+  ],
+  [
+   "element_refs['qd.61310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.61330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.61350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.61370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.61390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mpsh.61402'].knl[0]",
+   "(-vars['kmpsh61402'])"
+  ],
+  [
+   "element_refs['lsf.61405'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.61407'].knl[0]",
+   "(-vars['kmdh61407'])"
+  ],
+  [
+   "element_refs['qf.61410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mbb.61470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.61490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.61503'].ksl[0]",
+   "vars['kmpsv61503']"
+  ],
+  [
+   "element_refs['lsd.61505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.61507'].ksl[0]",
+   "vars['kmdv61507']"
+  ],
+  [
+   "element_refs['qd.61510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.61530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.61550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.61570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.61590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.61607'].knl[0]",
+   "(-vars['kmdh61607'])"
+  ],
+  [
+   "element_refs['qf.61610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mke.61631'].knl[0]",
+   "(-vars['kmke61631'])"
+  ],
+  [
+   "element_refs['mke.61634'].knl[0]",
+   "(-vars['kmke61634'])"
+  ],
+  [
+   "element_refs['mke.61637'].knl[0]",
+   "(-vars['kmke61637'])"
+  ],
+  [
+   "element_refs['mplh.61655'].knl[0]",
+   "(-vars['kmplh61655'])"
+  ],
+  [
+   "element_refs['mdva.61703'].ksl[0]",
+   "vars['kmdva61703']"
+  ],
+  [
+   "element_refs['qda.61710'].k1",
+   "vars['kqda']"
+  ],
+  [
+   "element_refs['mst.61779'].knl[0]",
+   "(-vars['kmst617'])"
+  ],
+  [
+   "element_refs['mst.61794'].knl[0]",
+   "(-vars['kmst617'])"
+  ],
+  [
+   "element_refs['qfa.61810'].k1",
+   "vars['kqfa']"
+  ],
+  [
+   "element_refs['mse.61832'].knl[0]",
+   "(-vars['kmse618'])"
+  ],
+  [
+   "element_refs['mse.61837'].knl[0]",
+   "(-vars['kmse618'])"
+  ],
+  [
+   "element_refs['mse.61852'].knl[0]",
+   "(-vars['kmse618'])"
+  ],
+  [
+   "element_refs['mse.61857'].knl[0]",
+   "(-vars['kmse618'])"
+  ],
+  [
+   "element_refs['mse.61872'].knl[0]",
+   "(-vars['kmse618'])"
+  ],
+  [
+   "element_refs['qda.61910'].k1",
+   "vars['kqda']"
+  ],
+  [
+   "element_refs['mdva.61932'].ksl[0]",
+   "vars['kmdva61932']"
+  ],
+  [
+   "element_refs['mplh.61996'].knl[0]",
+   "(-vars['kmplh61996'])"
+  ],
+  [
+   "element_refs['lsf.62005'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.62007'].knl[0]",
+   "(-vars['kmdh62007'])"
+  ],
+  [
+   "element_refs['qf.62010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.62030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.62070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.62103'].ksl[0]",
+   "vars['kmpsv62103']"
+  ],
+  [
+   "element_refs['mdv.62107'].ksl[0]",
+   "vars['kmdv62107']"
+  ],
+  [
+   "element_refs['qd.62110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.62130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsh.62199'].knl[0]",
+   "(-vars['kmpsh62199'])"
+  ],
+  [
+   "element_refs['lof.62202'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.62207'].knl[0]",
+   "(-vars['kmdh62207'])"
+  ],
+  [
+   "element_refs['qf.62210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.62230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.62270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mpsv.62303'].ksl[0]",
+   "vars['kmpsv62303']"
+  ],
+  [
+   "element_refs['lsd.62305'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.62307'].ksl[0]",
+   "vars['kmdv62307']"
+  ],
+  [
+   "element_refs['qd.62310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.62330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.62370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lse.62402'].k2",
+   "vars['klse62402']"
+  ],
+  [
+   "element_refs['lsf.62405'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.62407'].knl[0]",
+   "(-vars['kmdh62407'])"
+  ],
+  [
+   "element_refs['qf.62410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.62430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.62470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lsd.62505'].k2",
+   "vars['klsda']"
+  ],
+  [
+   "element_refs['mdv.62507'].ksl[0]",
+   "vars['kmdv62507']"
+  ],
+  [
+   "element_refs['qd.62510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.62530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.62570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.62602'].k3",
+   "(-vars['klof'])"
+  ],
+  [
+   "element_refs['lsf.62605'].k2",
+   "vars['klsfb']"
+  ],
+  [
+   "element_refs['mdh.62607'].knl[0]",
+   "(-vars['kmdh62607'])"
+  ],
+  [
+   "element_refs['qf.62610'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.62630'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62650'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.62670'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62690'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.62702'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['lsd.62705'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.62707'].ksl[0]",
+   "vars['kmdv62707']"
+  ],
+  [
+   "element_refs['qd.62710'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.62730'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62750'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.62770'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62790'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lof.62802'].k3",
+   "vars['klof']"
+  ],
+  [
+   "element_refs['mdh.62807'].knl[0]",
+   "(-vars['kmdh62807'])"
+  ],
+  [
+   "element_refs['qf.62810'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.62830'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62850'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.62870'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62890'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lqsa.62902'].k1s",
+   "vars['klqsa']"
+  ],
+  [
+   "element_refs['mdv.62907'].ksl[0]",
+   "vars['kmdv62907']"
+  ],
+  [
+   "element_refs['qd.62910'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.62930'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.62950'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.62970'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.62990'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loe.63002'].k3",
+   "vars['kloe63002']"
+  ],
+  [
+   "element_refs['mdh.63007'].knl[0]",
+   "(-vars['kmdh63007'])"
+  ],
+  [
+   "element_refs['qf.63010'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.63030'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.63050'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.63070'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.63090'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mdv.63107'].ksl[0]",
+   "vars['kmdv63107']"
+  ],
+  [
+   "element_refs['qd.63110'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.63130'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.63150'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.63170'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.63190'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['lsf.63205'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.63207'].knl[0]",
+   "(-vars['kmdh63207'])"
+  ],
+  [
+   "element_refs['qf.63210'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.63230'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.63250'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.63270'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.63290'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.63302'].k3",
+   "vars['klod']"
+  ],
+  [
+   "element_refs['mdv.63307'].ksl[0]",
+   "vars['kmdv63307']"
+  ],
+  [
+   "element_refs['qd.63310'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.63330'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.63350'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.63370'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.63390'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mdh.63407'].knl[0]",
+   "(-vars['kmdh63407'])"
+  ],
+  [
+   "element_refs['qf.63410'].k1",
+   "vars['kqf']"
+  ],
+  [
+   "element_refs['mba.63430'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.63450'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mbb.63470'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.63490'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['lod.63502'].k3",
+   "(-vars['klod'])"
+  ],
+  [
+   "element_refs['lsd.63505'].k2",
+   "vars['klsdb']"
+  ],
+  [
+   "element_refs['mdv.63507'].ksl[0]",
+   "vars['kmdv63507']"
+  ],
+  [
+   "element_refs['qd.63510'].k1",
+   "vars['kqd']"
+  ],
+  [
+   "element_refs['mbb.63530'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mbb.63550'].angle",
+   "vars['kmbb']"
+  ],
+  [
+   "element_refs['mba.63570'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['mba.63590'].angle",
+   "vars['kmba']"
+  ],
+  [
+   "element_refs['loe.63602'].k3",
+   "vars['kloe63602']"
+  ],
+  [
+   "element_refs['lsf.63605'].k2",
+   "vars['klsfa']"
+  ],
+  [
+   "element_refs['mdh.63607'].knl[0]",
+   "(-vars['kmdh63607'])"
+  ],
+  [
+   "vars['prad']",
+   "((vars['erad'] / vars['emass']) * vars['pmass'])"
+  ],
+  [
+   "vars['kqd']",
+   "((vars['kqd0'] + ((vars['qh_setvalue'] - vars['qx0']) * vars['dkqd_h'])) + ((vars['qv_setvalue'] - vars['qy0']) * vars['dkqd_v']))"
+  ],
+  [
+   "vars['kqda']",
+   "((vars['kqd'] * 9.0) / 11.0)"
+  ],
+  [
+   "vars['kqf']",
+   "((vars['kqf0'] + ((vars['qh_setvalue'] - vars['qx0']) * vars['dkqf_h'])) + ((vars['qv_setvalue'] - vars['qy0']) * vars['dkqf_v']))"
+  ],
+  [
+   "vars['kqfa']",
+   "((vars['kqf'] * 9.0) / 11.0)"
+  ],
+  [
+   "vars['klsda']",
+   "((vars['klsda0'] + (vars['logical.lsdaqph'] * vars['qph_setvalue'])) + (vars['logical.lsdaqpv'] * vars['qpv_setvalue']))"
+  ],
+  [
+   "vars['klsdb']",
+   "((vars['klsdb0'] + (vars['logical.lsdbqph'] * vars['qph_setvalue'])) + (vars['logical.lsdbqpv'] * vars['qpv_setvalue']))"
+  ],
+  [
+   "vars['klsfa']",
+   "((vars['klsfa0'] + (vars['logical.lsfaqph'] * vars['qph_setvalue'])) + (vars['logical.lsfaqpv'] * vars['qpv_setvalue']))"
+  ],
+  [
+   "vars['klsfb']",
+   "((vars['klsfb0'] + (vars['logical.lsfbqph'] * vars['qph_setvalue'])) + (vars['logical.lsfbqpv'] * vars['qpv_setvalue']))"
+  ],
+  [
+   "vars['klsfc']",
+   "((vars['klsfc0'] + (vars['logical.lsfcqph'] * vars['qph_setvalue'])) + (vars['logical.lsfcqpv'] * vars['qpv_setvalue']))"
+  ],
+  [
+   "vars['klsfc0']",
+   "vars['klsfa0']"
+  ],
+  [
+   "vars['logical.lsfcqph']",
+   "vars['logical.lsfaqph']"
+  ],
+  [
+   "vars['logical.lsfcqpv']",
+   "vars['logical.lsfaqpv']"
+  ],
+  [
+   "vars['freq800']",
+   "(4.0 * vars['freq200'])"
+  ],
+  [
+   "element_refs['actcse.31632'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcse.31632'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcse.31632'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcse.31637'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcse.31637'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcse.31637'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcse.31654'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcse.31654'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcse.31654'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsf.31672'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsf.31672'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsf.31672'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsf.31678'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsf.31678'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsf.31678'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsf.31695'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsf.31695'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsf.31695'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsg.31751'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsg.31751'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsg.31751'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsg.31758'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsg.31758'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsg.31758'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsg.31774'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsg.31774'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsg.31774'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsg.31780'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsg.31780'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsg.31780'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsh.31832'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsh.31832'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsh.31832'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsh.31838'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsh.31838'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsh.31838'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsh.31854'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsh.31854'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsh.31854'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsi.31872'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsi.31872'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsi.31872'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsi.31878'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsi.31878'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsi.31878'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsi.31895'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsi.31895'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsi.31895'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsj.31952'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsj.31952'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsj.31952'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsj.31958'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsj.31958'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsj.31958'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsj.31974'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsj.31974'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsj.31974'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['actcsj.31991'].frequency",
+   "vars['freq200']"
+  ],
+  [
+   "element_refs['actcsj.31991'].voltage",
+   "(vars['volt200'] / 20.0)"
+  ],
+  [
+   "element_refs['actcsj.31991'].lag",
+   "vars['lag200']"
+  ],
+  [
+   "element_refs['acl.31735'].frequency",
+   "vars['freq800']"
+  ],
+  [
+   "element_refs['acl.31735'].voltage",
+   "(vars['volt800'] / 2.0)"
+  ],
+  [
+   "element_refs['acl.31735'].lag",
+   "vars['lag800']"
+  ],
+  [
+   "element_refs['acl.31936'].frequency",
+   "vars['freq800']"
+  ],
+  [
+   "element_refs['acl.31936'].voltage",
+   "(vars['volt800'] / 2.0)"
+  ],
+  [
+   "element_refs['acl.31936'].lag",
+   "vars['lag800']"
+  ]
+ ],
+ "metadata": {},
+ "xsuite_data_type": "Environment",
+ "lines": {
+  "sps": {
+   "element_names": [
+    "begi.10010",
+    "qf.10010",
+    "drift_1",
+    "mba.10030",
+    "drift_2",
+    "mba.10050",
+    "drift_3",
+    "mbb.10070",
+    "drift_4",
+    "mbb.10090",
+    "drift_5",
+    "vvsa.10103",
+    "drift_6",
+    "lsd.10105",
+    "drift_7",
+    "mdv.10107",
+    "drift_8",
+    "bpv.10108",
+    "drift_9",
+    "qd.10110",
+    "drift_10",
+    "mbb.10130",
+    "drift_11",
+    "mbb.10150",
+    "drift_12",
+    "mba.10170",
+    "drift_13",
+    "mba.10190",
+    "drift_14",
+    "lsf.10205",
+    "drift_15",
+    "mdh.10207",
+    "drift_16",
+    "bph.10208",
+    "drift_17",
+    "qf.10210",
+    "drift_18",
+    "mba.10230",
+    "drift_19",
+    "mba.10250",
+    "drift_20",
+    "mbb.10270",
+    "drift_21",
+    "mbb.10290",
+    "drift_22",
+    "lod.10302",
+    "drift_23",
+    "lsd.10305",
+    "drift_24",
+    "mdv.10307",
+    "drift_25",
+    "bpv.10308",
+    "drift_26",
+    "qd.10310",
+    "drift_27",
+    "mbb.10330",
+    "drift_28",
+    "mbb.10350",
+    "drift_29",
+    "mba.10370",
+    "drift_30",
+    "mba.10390",
+    "drift_31",
+    "loe.10402",
+    "drift_32",
+    "mdh.10407",
+    "drift_33",
+    "bph.10408",
+    "drift_34",
+    "qf.10410",
+    "drift_35",
+    "mba.10430",
+    "drift_36",
+    "mba.10450",
+    "drift_37",
+    "mbb.10470",
+    "drift_38",
+    "mbb.10490",
+    "drift_39",
+    "mdv.10507",
+    "drift_40",
+    "bpv.10508",
+    "drift_41",
+    "qd.10510",
+    "drift_42",
+    "mbb.10530",
+    "drift_43",
+    "mbb.10550",
+    "drift_44",
+    "mba.10570",
+    "drift_45",
+    "mba.10590",
+    "drift_46",
+    "lse.10602",
+    "drift_47",
+    "mdh.10607",
+    "drift_48",
+    "bph.10608",
+    "drift_49",
+    "qf.10610",
+    "drift_50",
+    "mba.10630",
+    "drift_51",
+    "mba.10650",
+    "drift_52",
+    "mbb.10670",
+    "drift_53",
+    "mbb.10690",
+    "drift_54",
+    "lod.10702",
+    "drift_55",
+    "vvsa.10705",
+    "drift_56",
+    "mdv.10707",
+    "drift_57",
+    "bpv.10708",
+    "drift_58",
+    "qd.10710",
+    "drift_59",
+    "mbb.10730",
+    "drift_60",
+    "mbb.10750",
+    "drift_61",
+    "mba.10770",
+    "drift_62",
+    "mba.10790",
+    "drift_63",
+    "lof.10802",
+    "drift_64",
+    "lsf.10805",
+    "drift_65",
+    "mdh.10807",
+    "drift_66",
+    "bph.10808",
+    "drift_67",
+    "qf.10810",
+    "drift_68",
+    "mba.10830",
+    "drift_69",
+    "mba.10850",
+    "drift_70",
+    "mbb.10870",
+    "drift_71",
+    "mbb.10890",
+    "drift_72",
+    "mdv.10907",
+    "drift_73",
+    "bpv.10908",
+    "drift_74",
+    "qd.10910",
+    "drift_75",
+    "mbb.10930",
+    "drift_76",
+    "mbb.10950",
+    "drift_77",
+    "mba.10970",
+    "drift_78",
+    "mba.10990",
+    "drift_79",
+    "mdh.11007",
+    "drift_80",
+    "bph.11008",
+    "drift_81",
+    "qf.11010",
+    "drift_82",
+    "mba.11030",
+    "drift_83",
+    "mba.11050",
+    "drift_84",
+    "mbb.11070",
+    "drift_85",
+    "mbb.11090",
+    "drift_86",
+    "lsd.11105",
+    "drift_87",
+    "mdv.11107",
+    "drift_88",
+    "bpv.11108",
+    "drift_89",
+    "qd.11110",
+    "drift_90",
+    "mbb.11130",
+    "drift_91",
+    "mbb.11150",
+    "drift_92",
+    "mba.11170",
+    "drift_93",
+    "mba.11190",
+    "drift_94",
+    "lsf.11205",
+    "drift_95",
+    "mdh.11207",
+    "drift_96",
+    "bph.11208",
+    "drift_97",
+    "qf.11210",
+    "drift_98",
+    "mba.11230",
+    "drift_99",
+    "mba.11250",
+    "drift_100",
+    "mbb.11270",
+    "drift_101",
+    "mbb.11290",
+    "drift_102",
+    "vvsa.11303",
+    "drift_103",
+    "lsd.11305",
+    "drift_104",
+    "mdv.11307",
+    "drift_105",
+    "bpv.11308",
+    "drift_106",
+    "qd.11310",
+    "drift_107",
+    "mbb.11330",
+    "drift_108",
+    "mbb.11350",
+    "drift_109",
+    "mba.11370",
+    "drift_110",
+    "mba.11390",
+    "drift_111",
+    "qe.11402",
+    "drift_112",
+    "lsf.11405",
+    "drift_113",
+    "mdh.11407",
+    "drift_114",
+    "bph.11408",
+    "drift_115",
+    "qf.11410",
+    "drift_116",
+    "tidp.11434",
+    "drift_117",
+    "mbb.11470",
+    "drift_118",
+    "mbb.11490",
+    "drift_119",
+    "lsd.11505",
+    "drift_120",
+    "mdv.11507",
+    "drift_121",
+    "bpv.11508",
+    "drift_122",
+    "qd.11510",
+    "drift_123",
+    "mbb.11530",
+    "drift_124",
+    "mbb.11550",
+    "drift_125",
+    "mba.11570",
+    "drift_126",
+    "mba.11590",
+    "drift_127",
+    "mdh.11607",
+    "drift_128",
+    "bph.11608",
+    "drift_129",
+    "qf.11610",
+    "drift_130",
+    "qms.11631",
+    "drift_131",
+    "qms.11632",
+    "drift_132",
+    "qms.11634",
+    "drift_133",
+    "qms.11635",
+    "drift_134",
+    "bctfs.11640",
+    "drift_135",
+    "vvsb.11652",
+    "drift_136",
+    "mkqh.11653",
+    "drift_137",
+    "vvsb.11656",
+    "drift_138",
+    "btv.11656",
+    "drift_139",
+    "tbsm.11672",
+    "drift_140",
+    "vvsb.11678",
+    "drift_141",
+    "mkqv.11679",
+    "drift_142",
+    "vvsb.11692",
+    "drift_143",
+    "vvsb.11699",
+    "drift_144",
+    "mdv.11705",
+    "drift_145",
+    "bpv.11706",
+    "drift_146",
+    "qd.11710",
+    "drift_147",
+    "mdhw.11732",
+    "drift_148",
+    "mdhw.11737",
+    "drift_149",
+    "mdhw.11738",
+    "drift_150",
+    "mdhw.11754",
+    "drift_151",
+    "mdph.11757",
+    "drift_152",
+    "mdph.11758",
+    "drift_153",
+    "vvsb.11760",
+    "drift_154",
+    "bshv.11771",
+    "drift_155",
+    "bshv.11772",
+    "drift_156",
+    "bshv.11773",
+    "drift_157",
+    "tmasc.11802",
+    "drift_158",
+    "qf.11810",
+    "drift_159",
+    "mdh.11820",
+    "drift_160",
+    "bph.11831",
+    "drift_161",
+    "vvsb.11832",
+    "drift_162",
+    "bsmh.11859",
+    "btv.11860",
+    "drift_163",
+    "tmasc.11897",
+    "drift_164",
+    "vvsb.11903",
+    "drift_165",
+    "mdva.11904",
+    "drift_166",
+    "bpce.11906",
+    "drift_167",
+    "qda.11910",
+    "drift_168",
+    "mkpa.11931",
+    "drift_169",
+    "mkpa.11936",
+    "drift_170",
+    "mkpc.11952",
+    "drift_171",
+    "mkp.11955",
+    "drift_172",
+    "vvsb.11960",
+    "drift_173",
+    "mdsh.11971",
+    "drift_174",
+    "btv.11973",
+    "drift_175",
+    "btvs.11994",
+    "drift_176",
+    "tbsj.11995",
+    "drift_177",
+    "loe.12002",
+    "drift_178",
+    "lsf.12005",
+    "drift_179",
+    "mdh.12007",
+    "drift_180",
+    "bph.12008",
+    "drift_181",
+    "qf.12010",
+    "drift_182",
+    "mba.12030",
+    "drift_183",
+    "mba.12050",
+    "drift_184",
+    "mbb.12070",
+    "drift_185",
+    "mbb.12090",
+    "drift_186",
+    "mdv.12107",
+    "drift_187",
+    "bpv.12108",
+    "drift_188",
+    "qd.12110",
+    "drift_189",
+    "mbb.12130",
+    "drift_190",
+    "mbb.12150",
+    "drift_191",
+    "bpsh.12174",
+    "drift_192",
+    "bpsv.12179",
+    "drift_193",
+    "lof.12202",
+    "drift_194",
+    "mdh.12207",
+    "drift_195",
+    "bph.12208",
+    "drift_196",
+    "qf.12210",
+    "drift_197",
+    "mba.12230",
+    "drift_198",
+    "mba.12250",
+    "drift_199",
+    "mbb.12270",
+    "drift_200",
+    "mbb.12290",
+    "drift_201",
+    "vvsa.12301",
+    "drift_202",
+    "lsd.12305",
+    "drift_203",
+    "mdv.12307",
+    "drift_204",
+    "bpcn.12308",
+    "drift_205",
+    "qd.12310",
+    "drift_206",
+    "mbb.12330",
+    "drift_207",
+    "mbb.12350",
+    "drift_208",
+    "mba.12370",
+    "drift_209",
+    "mba.12390",
+    "drift_210",
+    "lse.12402",
+    "drift_211",
+    "lsf.12405",
+    "drift_212",
+    "mdh.12407",
+    "drift_213",
+    "bph.12408",
+    "drift_214",
+    "qf.12410",
+    "drift_215",
+    "mba.12430",
+    "drift_216",
+    "mba.12450",
+    "drift_217",
+    "mbb.12470",
+    "drift_218",
+    "mbb.12490",
+    "drift_219",
+    "lsd.12505",
+    "drift_220",
+    "mdv.12507",
+    "drift_221",
+    "bpcn.12508",
+    "drift_222",
+    "qd.12510",
+    "drift_223",
+    "mbb.12530",
+    "drift_224",
+    "mbb.12550",
+    "drift_225",
+    "mba.12570",
+    "drift_226",
+    "mba.12590",
+    "drift_227",
+    "lof.12602",
+    "drift_228",
+    "lsf.12605",
+    "drift_229",
+    "mdh.12607",
+    "drift_230",
+    "bph.12608",
+    "drift_231",
+    "qf.12610",
+    "drift_232",
+    "mba.12630",
+    "drift_233",
+    "mba.12650",
+    "drift_234",
+    "mbb.12670",
+    "drift_235",
+    "mbb.12690",
+    "drift_236",
+    "lod.12702",
+    "drift_237",
+    "lsd.12705",
+    "drift_238",
+    "mdv.12707",
+    "drift_239",
+    "bpv.12708",
+    "drift_240",
+    "qd.12710",
+    "drift_241",
+    "mbb.12730",
+    "drift_242",
+    "mbb.12750",
+    "drift_243",
+    "mba.12770",
+    "drift_244",
+    "mba.12790",
+    "drift_245",
+    "lof.12802",
+    "drift_246",
+    "mdh.12807",
+    "drift_247",
+    "bph.12808",
+    "drift_248",
+    "qf.12810",
+    "drift_249",
+    "mba.12830",
+    "drift_250",
+    "mba.12850",
+    "drift_251",
+    "mbb.12870",
+    "drift_252",
+    "mbb.12890",
+    "drift_253",
+    "lqsa.12902",
+    "drift_254",
+    "mdv.12907",
+    "drift_255",
+    "bpv.12908",
+    "drift_256",
+    "qd.12910",
+    "drift_257",
+    "mbb.12930",
+    "drift_258",
+    "mbb.12950",
+    "drift_259",
+    "mba.12970",
+    "drift_260",
+    "mba.12990",
+    "drift_261",
+    "loen.13002",
+    "drift_262",
+    "mdh.13007",
+    "drift_263",
+    "bph.13008",
+    "drift_264",
+    "qf.13010",
+    "drift_265",
+    "mba.13030",
+    "drift_266",
+    "mba.13050",
+    "drift_267",
+    "mbb.13070",
+    "drift_268",
+    "mbb.13090",
+    "drift_269",
+    "vvsa.13105",
+    "drift_270",
+    "mdv.13107",
+    "drift_271",
+    "bpv.13108",
+    "drift_272",
+    "qd.13110",
+    "drift_273",
+    "mbb.13130",
+    "drift_274",
+    "mbb.13150",
+    "drift_275",
+    "mba.13170",
+    "drift_276",
+    "mba.13190",
+    "drift_277",
+    "lsf.13205",
+    "drift_278",
+    "mdh.13207",
+    "drift_279",
+    "bph.13208",
+    "drift_280",
+    "qf.13210",
+    "drift_281",
+    "mba.13230",
+    "drift_282",
+    "mba.13250",
+    "drift_283",
+    "mbb.13270",
+    "drift_284",
+    "mbb.13290",
+    "drift_285",
+    "lod.13302",
+    "drift_286",
+    "mdv.13307",
+    "drift_287",
+    "bpv.13308",
+    "drift_288",
+    "qd.13310",
+    "drift_289",
+    "mbb.13330",
+    "drift_290",
+    "mbb.13350",
+    "drift_291",
+    "mba.13370",
+    "drift_292",
+    "mba.13390",
+    "drift_293",
+    "mdh.13407",
+    "drift_294",
+    "bph.13408",
+    "drift_295",
+    "qf.13410",
+    "drift_296",
+    "mba.13430",
+    "drift_297",
+    "mba.13450",
+    "drift_298",
+    "mbb.13470",
+    "drift_299",
+    "mbb.13490",
+    "drift_300",
+    "lod.13502",
+    "drift_301",
+    "lsd.13505",
+    "drift_302",
+    "mdv.13507",
+    "drift_303",
+    "bpv.13508",
+    "drift_304",
+    "qd.13510",
+    "drift_305",
+    "mbb.13530",
+    "drift_306",
+    "mbb.13550",
+    "drift_307",
+    "mba.13570",
+    "drift_308",
+    "mba.13590",
+    "drift_309",
+    "loe.13602",
+    "drift_310",
+    "lsf.13605",
+    "drift_311",
+    "mdh.13607",
+    "drift_312",
+    "bph.13608",
+    "drift_313",
+    "qf.20010",
+    "drift_314",
+    "mba.20030",
+    "drift_315",
+    "mba.20050",
+    "drift_316",
+    "mbb.20070",
+    "drift_317",
+    "mbb.20090",
+    "drift_318",
+    "vvsa.20101",
+    "drift_319",
+    "lsd.20105",
+    "drift_320",
+    "mdv.20107",
+    "drift_321",
+    "bpv.20108",
+    "drift_322",
+    "qd.20110",
+    "drift_323",
+    "mbb.20130",
+    "drift_324",
+    "mbb.20150",
+    "drift_325",
+    "mba.20170",
+    "drift_326",
+    "mba.20190",
+    "drift_327",
+    "bph.20203",
+    "drift_328",
+    "lsf.20205",
+    "drift_329",
+    "mdh.20207",
+    "drift_330",
+    "bph.20208",
+    "drift_331",
+    "qf.20210",
+    "drift_332",
+    "mba.20230",
+    "drift_333",
+    "mba.20250",
+    "drift_334",
+    "mbb.20270",
+    "drift_335",
+    "mbb.20290",
+    "drift_336",
+    "lod.20302",
+    "drift_337",
+    "lsd.20305",
+    "drift_338",
+    "mdv.20307",
+    "drift_339",
+    "bpv.20308",
+    "drift_340",
+    "qd.20310",
+    "drift_341",
+    "mbb.20330",
+    "drift_342",
+    "mbb.20350",
+    "drift_343",
+    "mba.20370",
+    "drift_344",
+    "mba.20390",
+    "drift_345",
+    "bpht.20406",
+    "drift_346",
+    "mdh.20407",
+    "drift_347",
+    "bph.20408",
+    "drift_348",
+    "qf.20410",
+    "drift_349",
+    "mba.20430",
+    "drift_350",
+    "mba.20450",
+    "drift_351",
+    "mbb.20470",
+    "drift_352",
+    "mbb.20490",
+    "drift_353",
+    "vvsa.20504",
+    "drift_354",
+    "bpv.20505",
+    "drift_355",
+    "mdv.20507",
+    "drift_356",
+    "bpv.20508",
+    "drift_357",
+    "qd.20510",
+    "drift_358",
+    "mbb.20530",
+    "drift_359",
+    "mbb.20550",
+    "drift_360",
+    "mba.20570",
+    "drift_361",
+    "mba.20590",
+    "drift_362",
+    "lse.20602",
+    "drift_363",
+    "mdh.20607",
+    "drift_364",
+    "bph.20608",
+    "drift_365",
+    "qf.20610",
+    "drift_366",
+    "mba.20630",
+    "drift_367",
+    "mba.20650",
+    "drift_368",
+    "mbb.20670",
+    "drift_369",
+    "mbb.20690",
+    "drift_370",
+    "lod.20702",
+    "drift_371",
+    "bpvc.20705",
+    "drift_372",
+    "mdv.20707",
+    "drift_373",
+    "bpv.20708",
+    "drift_374",
+    "qd.20710",
+    "drift_375",
+    "mbb.20730",
+    "drift_376",
+    "mbb.20750",
+    "drift_377",
+    "mba.20770",
+    "drift_378",
+    "mba.20790",
+    "drift_379",
+    "lof.20802",
+    "drift_380",
+    "lsf.20805",
+    "drift_381",
+    "mdh.20807",
+    "drift_382",
+    "bph.20808",
+    "drift_383",
+    "qf.20810",
+    "drift_384",
+    "mba.20830",
+    "drift_385",
+    "mba.20850",
+    "drift_386",
+    "mbb.20870",
+    "drift_387",
+    "mbb.20890",
+    "drift_388",
+    "bpcn.20902",
+    "drift_389",
+    "mdv.20907",
+    "drift_390",
+    "bpv.20908",
+    "drift_391",
+    "qd.20910",
+    "drift_392",
+    "mbb.20930",
+    "drift_393",
+    "mbb.20950",
+    "drift_394",
+    "mba.20970",
+    "drift_395",
+    "mba.20990",
+    "drift_396",
+    "bbsr.21001",
+    "btv.21003",
+    "drift_397",
+    "mdh.21007",
+    "drift_398",
+    "bph.21008",
+    "drift_399",
+    "qf.21010",
+    "drift_400",
+    "mba.21030",
+    "drift_401",
+    "mba.21050",
+    "drift_402",
+    "mbb.21070",
+    "drift_403",
+    "mbb.21090",
+    "drift_404",
+    "lsd.21105",
+    "drift_405",
+    "mdv.21107",
+    "drift_406",
+    "bpv.21108",
+    "drift_407",
+    "qd.21110",
+    "drift_408",
+    "mbb.21130",
+    "drift_409",
+    "mbb.21150",
+    "drift_410",
+    "mba.21170",
+    "drift_411",
+    "mba.21190",
+    "drift_412",
+    "mpsh.21202",
+    "drift_413",
+    "lsf.21205",
+    "drift_414",
+    "mdh.21207",
+    "drift_415",
+    "bph.21208",
+    "drift_416",
+    "qf.21210",
+    "drift_417",
+    "mba.21230",
+    "drift_418",
+    "mba.21250",
+    "drift_419",
+    "mbb.21270",
+    "drift_420",
+    "mbb.21290",
+    "drift_421",
+    "vvsa.21301",
+    "drift_422",
+    "mpsv.21303",
+    "drift_423",
+    "lsd.21305",
+    "drift_424",
+    "mdv.21307",
+    "drift_425",
+    "bpv.21308",
+    "drift_426",
+    "qd.21310",
+    "drift_427",
+    "mbb.21330",
+    "drift_428",
+    "mbb.21350",
+    "drift_429",
+    "mba.21370",
+    "drift_430",
+    "mba.21390",
+    "drift_431",
+    "bpcr.21402",
+    "drift_432",
+    "lsf.21405",
+    "drift_433",
+    "mdh.21407",
+    "drift_434",
+    "bph.21408",
+    "drift_435",
+    "qf.21410",
+    "drift_436",
+    "mplh.21431",
+    "drift_437",
+    "bpcr.21434",
+    "drift_438",
+    "bpcr.21436",
+    "drift_439",
+    "bdh.21437",
+    "drift_440",
+    "bdh.21451",
+    "drift_441",
+    "bdv.21455",
+    "drift_442",
+    "bpcr.21459",
+    "drift_443",
+    "mbb.21470",
+    "drift_444",
+    "mbb.21490",
+    "drift_445",
+    "mpsv.21503",
+    "drift_446",
+    "lsd.21505",
+    "drift_447",
+    "mdv.21507",
+    "drift_448",
+    "bpv.21508",
+    "drift_449",
+    "qd.21510",
+    "drift_450",
+    "mbb.21530",
+    "drift_451",
+    "mbb.21550",
+    "drift_452",
+    "mba.21570",
+    "drift_453",
+    "mba.21590",
+    "drift_454",
+    "tecs.21602",
+    "drift_455",
+    "vvsb.21603",
+    "drift_456",
+    "bpce.21604",
+    "drift_457",
+    "mdha.21606",
+    "drift_458",
+    "qfa.21610",
+    "drift_459",
+    "vmzsa.21632",
+    "drift_460",
+    "zs.21633",
+    "drift_461",
+    "vmzsb.21638",
+    "drift_462",
+    "zs.21639",
+    "drift_463",
+    "vmzsc.21654",
+    "drift_464",
+    "zs.21655",
+    "drift_465",
+    "vmzsc.21659",
+    "drift_466",
+    "zs.21671",
+    "drift_467",
+    "vmzsc.21675",
+    "drift_468",
+    "zs.21676",
+    "drift_469",
+    "vmzsd.21692",
+    "drift_470",
+    "tce.21695",
+    "drift_471",
+    "vvsb.21699",
+    "drift_472",
+    "vvfa.21701",
+    "drift_473",
+    "mdva.21703",
+    "drift_474",
+    "bpce.21706",
+    "drift_475",
+    "qda.21710",
+    "drift_476",
+    "mpnh.21732",
+    "drift_477",
+    "tpst.21760",
+    "vebx.21773",
+    "drift_478",
+    "mst.21774",
+    "drift_479",
+    "vebx.21778",
+    "drift_480",
+    "mst.21779",
+    "drift_481",
+    "vebx.21793",
+    "drift_482",
+    "mst.21794",
+    "drift_483",
+    "vebw.21798",
+    "drift_484",
+    "vvse.21799",
+    "drift_485",
+    "vvfb.21801",
+    "drift_486",
+    "bpce.21803",
+    "drift_487",
+    "mdha.21806",
+    "drift_488",
+    "qfa.21810",
+    "drift_489",
+    "vebw.21831",
+    "drift_490",
+    "mse.21832",
+    "drift_491",
+    "vebx.21836",
+    "drift_492",
+    "mse.21837",
+    "drift_493",
+    "vebx.21851",
+    "drift_494",
+    "mse.21852",
+    "drift_495",
+    "vebx.21856",
+    "drift_496",
+    "mse.21857",
+    "drift_497",
+    "vebx.21871",
+    "drift_498",
+    "mse.21872",
+    "drift_499",
+    "vebw.21876",
+    "drift_500",
+    "vvfb.21877",
+    "drift_501",
+    "vvsf.21880",
+    "drift_502",
+    "vvsb.21903",
+    "drift_503",
+    "qda.21910",
+    "drift_504",
+    "bpce.21931",
+    "drift_505",
+    "mdva.21932",
+    "drift_506",
+    "zkha.21991",
+    "drift_507",
+    "zkv.21993",
+    "drift_508",
+    "mplh.21995",
+    "drift_509",
+    "loe.22002",
+    "drift_510",
+    "lsf.22005",
+    "drift_511",
+    "mdh.22007",
+    "drift_512",
+    "bph.22008",
+    "drift_513",
+    "qf.22010",
+    "drift_514",
+    "mba.22030",
+    "drift_515",
+    "mba.22050",
+    "drift_516",
+    "mbb.22070",
+    "drift_517",
+    "mbb.22090",
+    "drift_518",
+    "mpsv.22103",
+    "drift_519",
+    "mdv.22107",
+    "drift_520",
+    "bpv.22108",
+    "drift_521",
+    "qd.22110",
+    "drift_522",
+    "mbb.22130",
+    "drift_523",
+    "mbb.22150",
+    "drift_524",
+    "bpcr.22172",
+    "drift_525",
+    "bdv.22176",
+    "drift_526",
+    "mplh.22195",
+    "drift_527",
+    "lof.22202",
+    "drift_528",
+    "mdh.22207",
+    "drift_529",
+    "bph.22208",
+    "drift_530",
+    "qf.22210",
+    "drift_531",
+    "mba.22230",
+    "drift_532",
+    "mba.22250",
+    "drift_533",
+    "mbb.22270",
+    "drift_534",
+    "mbb.22290",
+    "drift_535",
+    "vvsa.22301",
+    "drift_536",
+    "mpsv.22303",
+    "drift_537",
+    "lsd.22305",
+    "drift_538",
+    "mdv.22307",
+    "drift_539",
+    "bpcn.22308",
+    "drift_540",
+    "qd.22310",
+    "drift_541",
+    "mbb.22330",
+    "drift_542",
+    "mbb.22350",
+    "drift_543",
+    "mba.22370",
+    "drift_544",
+    "mba.22390",
+    "drift_545",
+    "lse.22402",
+    "drift_546",
+    "lsf.22405",
+    "drift_547",
+    "mdh.22407",
+    "drift_548",
+    "bph.22408",
+    "drift_549",
+    "qf.22410",
+    "drift_550",
+    "mba.22430",
+    "drift_551",
+    "mba.22450",
+    "drift_552",
+    "mbb.22470",
+    "drift_553",
+    "mbb.22490",
+    "drift_554",
+    "lsd.22505",
+    "drift_555",
+    "mdv.22507",
+    "drift_556",
+    "bpv.22508",
+    "drift_557",
+    "qd.22510",
+    "drift_558",
+    "mbb.22530",
+    "drift_559",
+    "mbb.22550",
+    "drift_560",
+    "mba.22570",
+    "drift_561",
+    "mba.22590",
+    "drift_562",
+    "lof.22602",
+    "drift_563",
+    "lsf.22605",
+    "drift_564",
+    "mdh.22607",
+    "drift_565",
+    "bph.22608",
+    "drift_566",
+    "qf.22610",
+    "drift_567",
+    "mba.22630",
+    "drift_568",
+    "mba.22650",
+    "drift_569",
+    "mbb.22670",
+    "drift_570",
+    "mbb.22690",
+    "drift_571",
+    "lod.22702",
+    "drift_572",
+    "lsd.22705",
+    "drift_573",
+    "mdv.22707",
+    "drift_574",
+    "bpcn.22708",
+    "drift_575",
+    "qd.22710",
+    "drift_576",
+    "mbb.22730",
+    "drift_577",
+    "mbb.22750",
+    "drift_578",
+    "mba.22770",
+    "drift_579",
+    "mba.22790",
+    "drift_580",
+    "lof.22802",
+    "drift_581",
+    "mdh.22807",
+    "drift_582",
+    "bph.22808",
+    "drift_583",
+    "qf.22810",
+    "drift_584",
+    "mba.22830",
+    "drift_585",
+    "mba.22850",
+    "drift_586",
+    "mbb.22870",
+    "drift_587",
+    "mbb.22890",
+    "drift_588",
+    "lqsa.22902",
+    "drift_589",
+    "mdv.22907",
+    "drift_590",
+    "bpv.22908",
+    "drift_591",
+    "qd.22910",
+    "drift_592",
+    "mbb.22930",
+    "drift_593",
+    "mbb.22950",
+    "drift_594",
+    "mba.22970",
+    "drift_595",
+    "mba.22990",
+    "drift_596",
+    "loen.23002",
+    "drift_597",
+    "mdh.23007",
+    "drift_598",
+    "bph.23008",
+    "drift_599",
+    "qf.23010",
+    "drift_600",
+    "mba.23030",
+    "drift_601",
+    "mba.23050",
+    "drift_602",
+    "mbb.23070",
+    "drift_603",
+    "mbb.23090",
+    "drift_604",
+    "vvsa.23105",
+    "drift_605",
+    "mdv.23107",
+    "drift_606",
+    "bpv.23108",
+    "drift_607",
+    "qd.23110",
+    "drift_608",
+    "mbb.23130",
+    "drift_609",
+    "mbb.23150",
+    "drift_610",
+    "mba.23170",
+    "drift_611",
+    "mba.23190",
+    "drift_612",
+    "lsf.23205",
+    "drift_613",
+    "mdh.23207",
+    "drift_614",
+    "bph.23208",
+    "drift_615",
+    "qf.23210",
+    "drift_616",
+    "mba.23230",
+    "drift_617",
+    "mba.23250",
+    "drift_618",
+    "mbb.23270",
+    "drift_619",
+    "mbb.23290",
+    "drift_620",
+    "lod.23302",
+    "drift_621",
+    "mdv.23307",
+    "drift_622",
+    "bpv.23308",
+    "drift_623",
+    "qd.23310",
+    "drift_624",
+    "mbb.23330",
+    "drift_625",
+    "mbb.23350",
+    "drift_626",
+    "mba.23370",
+    "drift_627",
+    "mba.23390",
+    "drift_628",
+    "mdh.23407",
+    "drift_629",
+    "bph.23408",
+    "drift_630",
+    "qf.23410",
+    "drift_631",
+    "mba.23430",
+    "drift_632",
+    "mba.23450",
+    "drift_633",
+    "mbb.23470",
+    "drift_634",
+    "mbb.23490",
+    "drift_635",
+    "lod.23502",
+    "drift_636",
+    "lsd.23505",
+    "drift_637",
+    "mdv.23507",
+    "drift_638",
+    "bpv.23508",
+    "drift_639",
+    "qd.23510",
+    "drift_640",
+    "mbb.23530",
+    "drift_641",
+    "mbb.23550",
+    "drift_642",
+    "mba.23570",
+    "drift_643",
+    "mba.23590",
+    "drift_644",
+    "loen.23602",
+    "drift_645",
+    "lsf.23605",
+    "drift_646",
+    "mdh.23607",
+    "drift_647",
+    "bph.23608",
+    "drift_648",
+    "qf.30010",
+    "drift_649",
+    "mba.30030",
+    "drift_650",
+    "mba.30050",
+    "drift_651",
+    "mbb.30070",
+    "drift_652",
+    "mbb.30090",
+    "drift_653",
+    "vvsa.30103",
+    "drift_654",
+    "lsd.30105",
+    "drift_655",
+    "mdv.30107",
+    "drift_656",
+    "bpv.30108",
+    "drift_657",
+    "qd.30110",
+    "drift_658",
+    "mbb.30130",
+    "drift_659",
+    "mbb.30150",
+    "drift_660",
+    "mba.30170",
+    "drift_661",
+    "mba.30190",
+    "drift_662",
+    "qe.30202",
+    "drift_663",
+    "lsf.30205",
+    "drift_664",
+    "mdh.30207",
+    "drift_665",
+    "bph.30208",
+    "drift_666",
+    "qf.30210",
+    "drift_667",
+    "mba.30230",
+    "drift_668",
+    "mba.30250",
+    "drift_669",
+    "mbb.30270",
+    "drift_670",
+    "mbb.30290",
+    "drift_671",
+    "lsd.30305",
+    "drift_672",
+    "mdv.30307",
+    "drift_673",
+    "bpv.30308",
+    "drift_674",
+    "qd.30310",
+    "drift_675",
+    "mbb.30330",
+    "drift_676",
+    "mbb.30350",
+    "drift_677",
+    "mba.30370",
+    "drift_678",
+    "mba.30390",
+    "drift_679",
+    "mdh.30407",
+    "drift_680",
+    "bph.30408",
+    "drift_681",
+    "qf.30410",
+    "drift_682",
+    "mba.30430",
+    "drift_683",
+    "mba.30450",
+    "drift_684",
+    "mbb.30470",
+    "drift_685",
+    "mbb.30490",
+    "drift_686",
+    "mdv.30507",
+    "drift_687",
+    "bpv.30508",
+    "drift_688",
+    "qd.30510",
+    "drift_689",
+    "mbb.30530",
+    "drift_690",
+    "mbb.30550",
+    "drift_691",
+    "mba.30570",
+    "drift_692",
+    "mba.30590",
+    "drift_693",
+    "qecd.30602",
+    "drift_694",
+    "mdh.30607",
+    "drift_695",
+    "bph.30608",
+    "drift_696",
+    "qf.30610",
+    "drift_697",
+    "mba.30630",
+    "drift_698",
+    "mba.30650",
+    "drift_699",
+    "mbb.30670",
+    "drift_700",
+    "mbb.30690",
+    "drift_701",
+    "lod.30702",
+    "drift_702",
+    "vvsa.30705",
+    "drift_703",
+    "mdv.30707",
+    "drift_704",
+    "bpv.30708",
+    "drift_705",
+    "qd.30710",
+    "drift_706",
+    "mbb.30730",
+    "drift_707",
+    "mbb.30750",
+    "drift_708",
+    "mba.30770",
+    "drift_709",
+    "mba.30790",
+    "drift_710",
+    "lof.30802",
+    "drift_711",
+    "lsf.30805",
+    "drift_712",
+    "mdh.30807",
+    "drift_713",
+    "bph.30808",
+    "drift_714",
+    "qf.30810",
+    "drift_715",
+    "mba.30830",
+    "drift_716",
+    "mba.30850",
+    "drift_717",
+    "mbb.30870",
+    "drift_718",
+    "mbb.30890",
+    "drift_719",
+    "aewa.30903",
+    "drift_720",
+    "mdv.30907",
+    "drift_721",
+    "bpv.30908",
+    "drift_722",
+    "qd.30910",
+    "drift_723",
+    "mbb.30930",
+    "drift_724",
+    "mbb.30950",
+    "drift_725",
+    "mba.30970",
+    "drift_726",
+    "mba.30990",
+    "drift_727",
+    "mdh.31007",
+    "drift_728",
+    "bph.31008",
+    "drift_729",
+    "qf.31010",
+    "drift_730",
+    "mba.31030",
+    "drift_731",
+    "mba.31050",
+    "drift_732",
+    "mbb.31070",
+    "drift_733",
+    "mbb.31090",
+    "drift_734",
+    "bpwa.31101",
+    "drift_735",
+    "lsd.31105",
+    "drift_736",
+    "mdv.31107",
+    "drift_737",
+    "bpv.31108",
+    "drift_738",
+    "qd.31110",
+    "drift_739",
+    "mbb.31130",
+    "drift_740",
+    "mbb.31150",
+    "drift_741",
+    "mba.31170",
+    "drift_742",
+    "mba.31190",
+    "drift_743",
+    "bpcr.31202",
+    "drift_744",
+    "lsf.31205",
+    "drift_745",
+    "mdh.31207",
+    "drift_746",
+    "bph.31208",
+    "drift_747",
+    "qf.31210",
+    "drift_748",
+    "mba.31230",
+    "drift_749",
+    "mba.31250",
+    "drift_750",
+    "mbb.31270",
+    "drift_751",
+    "mbb.31290",
+    "drift_752",
+    "vvsa.31301",
+    "aerb.31302",
+    "drift_753",
+    "lsd.31305",
+    "drift_754",
+    "mdv.31307",
+    "drift_755",
+    "bpv.31308",
+    "drift_756",
+    "qd.31310",
+    "drift_757",
+    "mbb.31330",
+    "drift_758",
+    "mbb.31350",
+    "drift_759",
+    "mba.31370",
+    "drift_760",
+    "mba.31390",
+    "drift_761",
+    "qecd.31402",
+    "drift_762",
+    "lsf.31405",
+    "drift_763",
+    "mdh.31407",
+    "drift_764",
+    "bph.31408",
+    "drift_765",
+    "qf.31410",
+    "drift_766",
+    "bctfr.31451",
+    "drift_767",
+    "bpw.31456",
+    "drift_768",
+    "bctdc.31458",
+    "drift_769",
+    "mbb.31470",
+    "drift_770",
+    "mbb.31490",
+    "drift_771",
+    "aewb.31502",
+    "drift_772",
+    "lsd.31505",
+    "drift_773",
+    "mdv.31507",
+    "drift_774",
+    "bpv.31508",
+    "drift_775",
+    "qd.31510",
+    "drift_776",
+    "mbb.31530",
+    "drift_777",
+    "mbb.31550",
+    "drift_778",
+    "mba.31570",
+    "drift_779",
+    "mba.31590",
+    "drift_780",
+    "bph.31605",
+    "drift_781",
+    "mdh.31607",
+    "drift_782",
+    "bph.31608",
+    "drift_783",
+    "qf.31610",
+    "drift_784",
+    "vvsb.31620",
+    "drift_785",
+    "actcse.31632",
+    "actcse.31637",
+    "actcse.31654",
+    "drift_786",
+    "vvsb.31671",
+    "drift_787",
+    "actcsf.31672",
+    "actcsf.31678",
+    "actcsf.31695",
+    "drift_788",
+    "vvsb.31706",
+    "drift_789",
+    "mdv.31707",
+    "drift_790",
+    "bpv.31708",
+    "drift_791",
+    "qd.31710",
+    "drift_792",
+    "aeta.31720",
+    "aew.31731",
+    "apwl.31731",
+    "aewa.31733",
+    "drift_793",
+    "aeg.31733",
+    "drift_794",
+    "acl.31735",
+    "drift_795",
+    "vvsb.31740",
+    "drift_796",
+    "actcsg.31751",
+    "actcsg.31758",
+    "actcsg.31774",
+    "actcsg.31780",
+    "drift_797",
+    "vvsb.31797",
+    "drift_798",
+    "aep.31799",
+    "aepc.31801",
+    "aepa.31804",
+    "drift_799",
+    "mdh.31807",
+    "drift_800",
+    "bph.31808",
+    "drift_801",
+    "qspl.31809",
+    "drift_802",
+    "qf.31810",
+    "drift_803",
+    "vvsb.31820",
+    "drift_804",
+    "actcsh.31832",
+    "actcsh.31838",
+    "actcsh.31854",
+    "drift_805",
+    "vvsb.31871",
+    "drift_806",
+    "actcsi.31872",
+    "actcsi.31878",
+    "actcsi.31895",
+    "drift_807",
+    "vvsb.31906",
+    "drift_808",
+    "mdv.31907",
+    "drift_809",
+    "bpv.31908",
+    "drift_810",
+    "qd.31910",
+    "drift_811",
+    "bctw.31931",
+    "drift_812",
+    "aesa.31931",
+    "drift_813",
+    "bpwc.31933",
+    "drift_814",
+    "acl.31936",
+    "drift_815",
+    "vvsb.31951",
+    "drift_816",
+    "actcsj.31952",
+    "actcsj.31958",
+    "actcsj.31974",
+    "actcsj.31991",
+    "drift_817",
+    "vvsb.31997",
+    "drift_818",
+    "loe.32002",
+    "drift_819",
+    "lsf.32005",
+    "drift_820",
+    "mdh.32007",
+    "drift_821",
+    "bph.32008",
+    "drift_822",
+    "qf.32010",
+    "drift_823",
+    "mba.32030",
+    "drift_824",
+    "mba.32050",
+    "drift_825",
+    "mbb.32070",
+    "drift_826",
+    "mbb.32090",
+    "drift_827",
+    "bpwb.32101",
+    "drift_828",
+    "mdv.32107",
+    "drift_829",
+    "bpv.32108",
+    "drift_830",
+    "qd.32110",
+    "drift_831",
+    "mbb.32130",
+    "drift_832",
+    "mbb.32150",
+    "drift_833",
+    "adkcv.32171",
+    "drift_834",
+    "adkcv.32172",
+    "drift_835",
+    "adksv.32173",
+    "drift_836",
+    "lof.32202",
+    "drift_837",
+    "mdh.32207",
+    "drift_838",
+    "bph.32208",
+    "drift_839",
+    "qf.32210",
+    "drift_840",
+    "mba.32230",
+    "drift_841",
+    "mba.32250",
+    "drift_842",
+    "mbb.32270",
+    "drift_843",
+    "mbb.32290",
+    "drift_844",
+    "vvsa.32303",
+    "drift_845",
+    "lsd.32305",
+    "drift_846",
+    "mdv.32307",
+    "drift_847",
+    "bpcn.32308",
+    "drift_848",
+    "qd.32310",
+    "drift_849",
+    "mbb.32330",
+    "drift_850",
+    "mbb.32350",
+    "drift_851",
+    "mba.32370",
+    "drift_852",
+    "mba.32390",
+    "drift_853",
+    "lse.32402",
+    "drift_854",
+    "lsf.32405",
+    "drift_855",
+    "mdh.32407",
+    "drift_856",
+    "bph.32408",
+    "drift_857",
+    "qf.32410",
+    "drift_858",
+    "mba.32430",
+    "drift_859",
+    "mba.32450",
+    "drift_860",
+    "mbb.32470",
+    "drift_861",
+    "mbb.32490",
+    "drift_862",
+    "lsd.32505",
+    "drift_863",
+    "mdv.32507",
+    "drift_864",
+    "bpv.32508",
+    "drift_865",
+    "qd.32510",
+    "drift_866",
+    "mbb.32530",
+    "drift_867",
+    "mbb.32550",
+    "drift_868",
+    "mba.32570",
+    "drift_869",
+    "mba.32590",
+    "drift_870",
+    "lof.32602",
+    "drift_871",
+    "lsf.32605",
+    "drift_872",
+    "mdh.32607",
+    "drift_873",
+    "bph.32608",
+    "drift_874",
+    "qf.32610",
+    "drift_875",
+    "mba.32630",
+    "drift_876",
+    "mba.32650",
+    "drift_877",
+    "mbb.32670",
+    "drift_878",
+    "mbb.32690",
+    "drift_879",
+    "lod.32702",
+    "drift_880",
+    "lsd.32705",
+    "drift_881",
+    "mdv.32707",
+    "drift_882",
+    "bpcn.32708",
+    "drift_883",
+    "qd.32710",
+    "drift_884",
+    "mbb.32730",
+    "drift_885",
+    "mbb.32750",
+    "drift_886",
+    "mba.32770",
+    "drift_887",
+    "mba.32790",
+    "drift_888",
+    "lof.32802",
+    "drift_889",
+    "mdh.32807",
+    "drift_890",
+    "bph.32808",
+    "drift_891",
+    "qf.32810",
+    "drift_892",
+    "mba.32830",
+    "drift_893",
+    "mba.32850",
+    "drift_894",
+    "mbb.32870",
+    "drift_895",
+    "mbb.32890",
+    "drift_896",
+    "lqsa.32902",
+    "drift_897",
+    "mdv.32907",
+    "drift_898",
+    "bpv.32908",
+    "drift_899",
+    "qd.32910",
+    "drift_900",
+    "mbb.32930",
+    "drift_901",
+    "mbb.32950",
+    "drift_902",
+    "mba.32970",
+    "drift_903",
+    "mba.32990",
+    "drift_904",
+    "loe.33002",
+    "drift_905",
+    "mdh.33007",
+    "drift_906",
+    "bph.33008",
+    "drift_907",
+    "qf.33010",
+    "drift_908",
+    "mba.33030",
+    "drift_909",
+    "mba.33050",
+    "drift_910",
+    "mbb.33070",
+    "drift_911",
+    "mbb.33090",
+    "drift_912",
+    "vvsa.33105",
+    "drift_913",
+    "mdv.33107",
+    "drift_914",
+    "bpv.33108",
+    "drift_915",
+    "qd.33110",
+    "drift_916",
+    "mbb.33130",
+    "drift_917",
+    "mbb.33150",
+    "drift_918",
+    "mba.33170",
+    "drift_919",
+    "mba.33190",
+    "drift_920",
+    "lsf.33205",
+    "drift_921",
+    "mdh.33207",
+    "drift_922",
+    "bph.33208",
+    "drift_923",
+    "qf.33210",
+    "drift_924",
+    "mba.33230",
+    "drift_925",
+    "mba.33250",
+    "drift_926",
+    "mbb.33270",
+    "drift_927",
+    "mbb.33290",
+    "drift_928",
+    "lod.33302",
+    "drift_929",
+    "mdv.33307",
+    "drift_930",
+    "bpv.33308",
+    "drift_931",
+    "qd.33310",
+    "drift_932",
+    "mbb.33330",
+    "drift_933",
+    "mbb.33350",
+    "drift_934",
+    "mba.33370",
+    "drift_935",
+    "mba.33390",
+    "drift_936",
+    "aepa.33404",
+    "drift_937",
+    "mdh.33407",
+    "drift_938",
+    "bph.33408",
+    "drift_939",
+    "qf.33410",
+    "drift_940",
+    "mba.33430",
+    "drift_941",
+    "mba.33450",
+    "drift_942",
+    "mbb.33470",
+    "drift_943",
+    "mbb.33490",
+    "drift_944",
+    "lod.33502",
+    "drift_945",
+    "lsd.33505",
+    "drift_946",
+    "mdv.33507",
+    "drift_947",
+    "bpv.33508",
+    "drift_948",
+    "qd.33510",
+    "drift_949",
+    "mbb.33530",
+    "drift_950",
+    "mbb.33550",
+    "drift_951",
+    "mba.33570",
+    "drift_952",
+    "mba.33590",
+    "drift_953",
+    "loe.33602",
+    "drift_954",
+    "lsf.33605",
+    "drift_955",
+    "mdh.33607",
+    "drift_956",
+    "bph.33608",
+    "drift_957",
+    "qf.40010",
+    "drift_958",
+    "mba.40030",
+    "drift_959",
+    "mba.40050",
+    "drift_960",
+    "mbb.40070",
+    "drift_961",
+    "mbb.40090",
+    "drift_962",
+    "vvsa.40103",
+    "drift_963",
+    "lsd.40105",
+    "drift_964",
+    "mdv.40107",
+    "drift_965",
+    "bpv.40108",
+    "drift_966",
+    "qd.40110",
+    "drift_967",
+    "mbb.40130",
+    "drift_968",
+    "mbb.40150",
+    "drift_969",
+    "mba.40170",
+    "drift_970",
+    "mba.40190",
+    "drift_971",
+    "lsf.40205",
+    "drift_972",
+    "mdh.40207",
+    "drift_973",
+    "bph.40208",
+    "drift_974",
+    "qf.40210",
+    "drift_975",
+    "mba.40230",
+    "drift_976",
+    "mba.40250",
+    "drift_977",
+    "mbb.40270",
+    "drift_978",
+    "mbb.40290",
+    "drift_979",
+    "lod.40302",
+    "drift_980",
+    "lsd.40305",
+    "drift_981",
+    "mdv.40307",
+    "drift_982",
+    "bpv.40308",
+    "drift_983",
+    "qd.40310",
+    "drift_984",
+    "mbb.40330",
+    "drift_985",
+    "mbb.40350",
+    "drift_986",
+    "mba.40370",
+    "drift_987",
+    "mba.40390",
+    "drift_988",
+    "loe.40402",
+    "drift_989",
+    "mdh.40407",
+    "drift_990",
+    "bph.40408",
+    "drift_991",
+    "qf.40410",
+    "drift_992",
+    "mba.40430",
+    "drift_993",
+    "mba.40450",
+    "drift_994",
+    "mbb.40470",
+    "drift_995",
+    "mbb.40490",
+    "drift_996",
+    "mdv.40507",
+    "drift_997",
+    "bpv.40508",
+    "drift_998",
+    "qd.40510",
+    "drift_999",
+    "mbb.40530",
+    "drift_1000",
+    "mbb.40550",
+    "drift_1001",
+    "mba.40570",
+    "drift_1002",
+    "mba.40590",
+    "drift_1003",
+    "lse.40602",
+    "drift_1004",
+    "mdh.40607",
+    "drift_1005",
+    "bph.40608",
+    "drift_1006",
+    "qf.40610",
+    "drift_1007",
+    "mba.40630",
+    "drift_1008",
+    "mba.40650",
+    "drift_1009",
+    "mbb.40670",
+    "drift_1010",
+    "mbb.40690",
+    "drift_1011",
+    "lod.40702",
+    "drift_1012",
+    "vvsa.40705",
+    "drift_1013",
+    "mdv.40707",
+    "drift_1014",
+    "bpv.40708",
+    "drift_1015",
+    "qd.40710",
+    "drift_1016",
+    "mbb.40730",
+    "drift_1017",
+    "mbb.40750",
+    "drift_1018",
+    "mba.40770",
+    "drift_1019",
+    "mba.40790",
+    "drift_1020",
+    "lof.40802",
+    "drift_1021",
+    "lsf.40805",
+    "drift_1022",
+    "mdh.40807",
+    "drift_1023",
+    "bph.40808",
+    "drift_1024",
+    "qf.40810",
+    "drift_1025",
+    "mba.40830",
+    "drift_1026",
+    "mba.40850",
+    "drift_1027",
+    "mbb.40870",
+    "drift_1028",
+    "mbb.40890",
+    "drift_1029",
+    "mdv.40907",
+    "drift_1030",
+    "bpv.40908",
+    "drift_1031",
+    "qd.40910",
+    "drift_1032",
+    "mbb.40930",
+    "drift_1033",
+    "mbb.40950",
+    "drift_1034",
+    "mba.40970",
+    "drift_1035",
+    "mba.40990",
+    "drift_1036",
+    "mdh.41007",
+    "drift_1037",
+    "bph.41008",
+    "drift_1038",
+    "qf.41010",
+    "drift_1039",
+    "mba.41030",
+    "drift_1040",
+    "mba.41050",
+    "drift_1041",
+    "mbb.41070",
+    "drift_1042",
+    "mbb.41090",
+    "drift_1043",
+    "lsd.41105",
+    "drift_1044",
+    "mdv.41107",
+    "drift_1045",
+    "bpv.41108",
+    "drift_1046",
+    "qd.41110",
+    "drift_1047",
+    "mbb.41130",
+    "drift_1048",
+    "mbb.41150",
+    "drift_1049",
+    "mba.41170",
+    "drift_1050",
+    "mba.41190",
+    "drift_1051",
+    "lsf.41205",
+    "drift_1052",
+    "mdh.41207",
+    "drift_1053",
+    "bph.41208",
+    "drift_1054",
+    "qf.41210",
+    "drift_1055",
+    "mba.41230",
+    "drift_1056",
+    "mba.41250",
+    "drift_1057",
+    "mbb.41270",
+    "drift_1058",
+    "mbb.41290",
+    "drift_1059",
+    "vvsa.41301",
+    "drift_1060",
+    "mpsv.41303",
+    "drift_1061",
+    "lsd.41305",
+    "drift_1062",
+    "mdv.41307",
+    "drift_1063",
+    "bpv.41308",
+    "drift_1064",
+    "qd.41310",
+    "drift_1065",
+    "mbb.41330",
+    "drift_1066",
+    "mbb.41350",
+    "drift_1067",
+    "mba.41370",
+    "drift_1068",
+    "mba.41390",
+    "drift_1069",
+    "mpsh.41402",
+    "drift_1070",
+    "lsf.41405",
+    "drift_1071",
+    "mdh.41407",
+    "drift_1072",
+    "bph.41408",
+    "drift_1073",
+    "qf.41410",
+    "drift_1074",
+    "bwsa.41420",
+    "drift_1075",
+    "bctdc.41435",
+    "drift_1076",
+    "bctfs.41438",
+    "drift_1077",
+    "mbb.41470",
+    "drift_1078",
+    "mbb.41490",
+    "drift_1079",
+    "mplv.41501",
+    "drift_1080",
+    "lsd.41505",
+    "drift_1081",
+    "mdv.41507",
+    "drift_1082",
+    "bpv.41508",
+    "drift_1083",
+    "qd.41510",
+    "drift_1084",
+    "mbb.41530",
+    "drift_1085",
+    "mbb.41550",
+    "drift_1086",
+    "mba.41570",
+    "drift_1087",
+    "mba.41590",
+    "drift_1088",
+    "mdh.41607",
+    "drift_1089",
+    "bph.41607",
+    "drift_1090",
+    "qf.41610",
+    "drift_1091",
+    "vvsb.41620",
+    "drift_1092",
+    "mke.41631",
+    "drift_1093",
+    "mke.41634",
+    "drift_1094",
+    "mke.41637",
+    "drift_1095",
+    "mke.41651",
+    "drift_1096",
+    "vvsb.41658",
+    "drift_1097",
+    "mplh.41658",
+    "drift_1098",
+    "bwsrc.41677",
+    "drift_1099",
+    "bwsrc.41678",
+    "drift_1100",
+    "vvfa.41698",
+    "drift_1101",
+    "mdva.41703",
+    "drift_1102",
+    "bpce.41705",
+    "drift_1103",
+    "qda.41710",
+    "drift_1104",
+    "vvsb.41731",
+    "xcld.41737",
+    "vvsb.41757",
+    "drift_1105",
+    "teca.41777",
+    "drift_1106",
+    "vvsb.41779",
+    "drift_1107",
+    "btvt.41797",
+    "drift_1108",
+    "tpsc4j.41797",
+    "drift_1109",
+    "bpce.41801",
+    "drift_1110",
+    "mdha.41804",
+    "drift_1111",
+    "qfa.41810",
+    "drift_1112",
+    "btve.41831",
+    "drift_1113",
+    "tpsg.41832",
+    "drift_1114",
+    "mse.41837",
+    "drift_1115",
+    "veby.41851",
+    "drift_1116",
+    "mse.41852",
+    "drift_1117",
+    "veby.41855",
+    "drift_1118",
+    "mse.41856",
+    "drift_1119",
+    "mse.41871",
+    "drift_1120",
+    "mse.41876",
+    "drift_1121",
+    "mse.41891",
+    "drift_1122",
+    "btve.41895",
+    "drift_1123",
+    "vvsb.41904",
+    "drift_1124",
+    "qda.41910",
+    "drift_1125",
+    "bpce.41931",
+    "drift_1126",
+    "mdva.41932",
+    "drift_1127",
+    "mplh.41994",
+    "drift_1128",
+    "lsf.42005",
+    "drift_1129",
+    "mdh.42007",
+    "drift_1130",
+    "bph.42008",
+    "drift_1131",
+    "qf.42010",
+    "drift_1132",
+    "mba.42030",
+    "drift_1133",
+    "mba.42050",
+    "drift_1134",
+    "mbb.42070",
+    "drift_1135",
+    "mbb.42090",
+    "drift_1136",
+    "mplv.42101",
+    "drift_1137",
+    "bpmec.42105",
+    "drift_1138",
+    "mdv.42107",
+    "drift_1139",
+    "bpv.42108",
+    "drift_1140",
+    "qd.42110",
+    "drift_1141",
+    "mbb.42130",
+    "drift_1142",
+    "mbb.42150",
+    "drift_1143",
+    "bpcl.42171",
+    "drift_1144",
+    "mpsh.42198",
+    "drift_1145",
+    "lof.42202",
+    "drift_1146",
+    "mdh.42207",
+    "drift_1147",
+    "bph.42208",
+    "drift_1148",
+    "qf.42210",
+    "drift_1149",
+    "mba.42230",
+    "drift_1150",
+    "mba.42250",
+    "drift_1151",
+    "mbb.42270",
+    "drift_1152",
+    "mbb.42290",
+    "drift_1153",
+    "vvsa.42301",
+    "drift_1154",
+    "mpsv.42303",
+    "drift_1155",
+    "lsd.42305",
+    "drift_1156",
+    "mdv.42307",
+    "drift_1157",
+    "bpv.42308",
+    "drift_1158",
+    "qd.42310",
+    "drift_1159",
+    "mbb.42330",
+    "drift_1160",
+    "mbb.42350",
+    "drift_1161",
+    "mba.42370",
+    "drift_1162",
+    "mba.42390",
+    "drift_1163",
+    "lsen.42402",
+    "drift_1164",
+    "lsf.42405",
+    "drift_1165",
+    "mdh.42407",
+    "drift_1166",
+    "bph.42408",
+    "drift_1167",
+    "qf.42410",
+    "drift_1168",
+    "mba.42430",
+    "drift_1169",
+    "mba.42450",
+    "drift_1170",
+    "mbb.42470",
+    "drift_1171",
+    "mbb.42490",
+    "drift_1172",
+    "lsd.42505",
+    "drift_1173",
+    "mdv.42507",
+    "drift_1174",
+    "bpv.42508",
+    "drift_1175",
+    "qd.42510",
+    "drift_1176",
+    "mbb.42530",
+    "drift_1177",
+    "mbb.42550",
+    "drift_1178",
+    "mba.42570",
+    "drift_1179",
+    "mba.42590",
+    "drift_1180",
+    "lof.42602",
+    "drift_1181",
+    "lsf.42605",
+    "drift_1182",
+    "mdh.42607",
+    "drift_1183",
+    "bph.42608",
+    "drift_1184",
+    "qf.42610",
+    "drift_1185",
+    "mba.42630",
+    "drift_1186",
+    "mba.42650",
+    "drift_1187",
+    "mbb.42670",
+    "drift_1188",
+    "mbb.42690",
+    "drift_1189",
+    "lod.42702",
+    "drift_1190",
+    "lsd.42705",
+    "drift_1191",
+    "mdv.42707",
+    "drift_1192",
+    "bpv.42708",
+    "drift_1193",
+    "qd.42710",
+    "drift_1194",
+    "mbb.42730",
+    "drift_1195",
+    "mbb.42750",
+    "drift_1196",
+    "mba.42770",
+    "drift_1197",
+    "mba.42790",
+    "drift_1198",
+    "lof.42802",
+    "drift_1199",
+    "mdh.42807",
+    "drift_1200",
+    "bph.42808",
+    "drift_1201",
+    "qf.42810",
+    "drift_1202",
+    "mba.42830",
+    "drift_1203",
+    "mba.42850",
+    "drift_1204",
+    "mbb.42870",
+    "drift_1205",
+    "mbb.42890",
+    "drift_1206",
+    "lqsa.42902",
+    "drift_1207",
+    "mdv.42907",
+    "drift_1208",
+    "bpv.42908",
+    "drift_1209",
+    "qd.42910",
+    "drift_1210",
+    "mbb.42930",
+    "drift_1211",
+    "mbb.42950",
+    "drift_1212",
+    "mba.42970",
+    "drift_1213",
+    "mba.42990",
+    "drift_1214",
+    "mdh.43007",
+    "drift_1215",
+    "bph.43008",
+    "drift_1216",
+    "qf.43010",
+    "drift_1217",
+    "mba.43030",
+    "drift_1218",
+    "mba.43050",
+    "drift_1219",
+    "mbb.43070",
+    "drift_1220",
+    "mbb.43090",
+    "drift_1221",
+    "vvsa.43101",
+    "drift_1222",
+    "mdv.43107",
+    "drift_1223",
+    "bpv.43108",
+    "drift_1224",
+    "qd.43110",
+    "drift_1225",
+    "mbb.43130",
+    "drift_1226",
+    "mbb.43150",
+    "drift_1227",
+    "mba.43170",
+    "drift_1228",
+    "mba.43190",
+    "drift_1229",
+    "lsf.43205",
+    "drift_1230",
+    "mdh.43207",
+    "drift_1231",
+    "bph.43208",
+    "drift_1232",
+    "qf.43210",
+    "drift_1233",
+    "mba.43230",
+    "drift_1234",
+    "mba.43250",
+    "drift_1235",
+    "mbb.43270",
+    "drift_1236",
+    "mbb.43290",
+    "drift_1237",
+    "lod.43302",
+    "drift_1238",
+    "mdv.43307",
+    "drift_1239",
+    "bpv.43308",
+    "drift_1240",
+    "qd.43310",
+    "drift_1241",
+    "mbb.43330",
+    "drift_1242",
+    "mbb.43350",
+    "drift_1243",
+    "mba.43370",
+    "drift_1244",
+    "mba.43390",
+    "drift_1245",
+    "mdh.43407",
+    "drift_1246",
+    "bph.43408",
+    "drift_1247",
+    "qf.43410",
+    "drift_1248",
+    "mba.43430",
+    "drift_1249",
+    "mba.43450",
+    "drift_1250",
+    "mbb.43470",
+    "drift_1251",
+    "mbb.43490",
+    "drift_1252",
+    "lod.43502",
+    "drift_1253",
+    "lsd.43505",
+    "drift_1254",
+    "mdv.43507",
+    "drift_1255",
+    "bpv.43508",
+    "drift_1256",
+    "qd.43510",
+    "drift_1257",
+    "mbb.43530",
+    "drift_1258",
+    "mbb.43550",
+    "drift_1259",
+    "mba.43570",
+    "drift_1260",
+    "mba.43590",
+    "drift_1261",
+    "lsf.43605",
+    "drift_1262",
+    "mdh.43607",
+    "drift_1263",
+    "bph.43608",
+    "drift_1264",
+    "qf.50010",
+    "drift_1265",
+    "mba.50030",
+    "drift_1266",
+    "mba.50050",
+    "drift_1267",
+    "mbb.50070",
+    "drift_1268",
+    "mbb.50090",
+    "drift_1269",
+    "vvsa.50101",
+    "drift_1270",
+    "lsd.50105",
+    "drift_1271",
+    "mdv.50107",
+    "drift_1272",
+    "bpv.50108",
+    "drift_1273",
+    "qd.50110",
+    "drift_1274",
+    "mbb.50130",
+    "drift_1275",
+    "mbb.50150",
+    "drift_1276",
+    "mba.50170",
+    "drift_1277",
+    "mba.50190",
+    "drift_1278",
+    "qe.50202",
+    "drift_1279",
+    "lsf.50205",
+    "drift_1280",
+    "mdh.50207",
+    "drift_1281",
+    "bph.50208",
+    "drift_1282",
+    "qf.50210",
+    "drift_1283",
+    "mba.50230",
+    "drift_1284",
+    "mba.50250",
+    "drift_1285",
+    "mbb.50270",
+    "drift_1286",
+    "mbb.50290",
+    "drift_1287",
+    "lod.50302",
+    "drift_1288",
+    "lsd.50305",
+    "drift_1289",
+    "mdv.50307",
+    "drift_1290",
+    "bpv.50308",
+    "drift_1291",
+    "qd.50310",
+    "drift_1292",
+    "mbb.50330",
+    "drift_1293",
+    "mbb.50350",
+    "drift_1294",
+    "mba.50370",
+    "drift_1295",
+    "mba.50390",
+    "drift_1296",
+    "loen.50402",
+    "drift_1297",
+    "mdh.50407",
+    "drift_1298",
+    "bph.50408",
+    "drift_1299",
+    "qf.50410",
+    "drift_1300",
+    "mba.50430",
+    "drift_1301",
+    "mba.50450",
+    "drift_1302",
+    "mbb.50470",
+    "drift_1303",
+    "mbb.50490",
+    "drift_1304",
+    "mdv.50507",
+    "drift_1305",
+    "bpv.50508",
+    "drift_1306",
+    "qd.50510",
+    "drift_1307",
+    "mbb.50530",
+    "drift_1308",
+    "mbb.50550",
+    "drift_1309",
+    "mba.50570",
+    "drift_1310",
+    "mba.50590",
+    "drift_1311",
+    "lse.50602",
+    "drift_1312",
+    "mdh.50607",
+    "drift_1313",
+    "bph.50608",
+    "drift_1314",
+    "qf.50610",
+    "drift_1315",
+    "mba.50630",
+    "drift_1316",
+    "mba.50650",
+    "drift_1317",
+    "mbb.50670",
+    "drift_1318",
+    "mbb.50690",
+    "drift_1319",
+    "lod.50702",
+    "drift_1320",
+    "vvsa.50705",
+    "drift_1321",
+    "mdv.50707",
+    "drift_1322",
+    "bpv.50708",
+    "drift_1323",
+    "qd.50710",
+    "drift_1324",
+    "mbb.50730",
+    "drift_1325",
+    "mbb.50750",
+    "drift_1326",
+    "mba.50770",
+    "drift_1327",
+    "mba.50790",
+    "drift_1328",
+    "lof.50802",
+    "drift_1329",
+    "lsf.50805",
+    "drift_1330",
+    "mdh.50807",
+    "drift_1331",
+    "bph.50808",
+    "drift_1332",
+    "qf.50810",
+    "drift_1333",
+    "mba.50830",
+    "drift_1334",
+    "mba.50850",
+    "drift_1335",
+    "mbb.50870",
+    "drift_1336",
+    "mbb.50890",
+    "drift_1337",
+    "mdv.50907",
+    "drift_1338",
+    "bpv.50908",
+    "drift_1339",
+    "qd.50910",
+    "drift_1340",
+    "mbb.50930",
+    "drift_1341",
+    "mbb.50950",
+    "drift_1342",
+    "mba.50970",
+    "drift_1343",
+    "mba.50990",
+    "drift_1344",
+    "mdh.51007",
+    "drift_1345",
+    "bph.51008",
+    "drift_1346",
+    "qf.51010",
+    "drift_1347",
+    "mba.51030",
+    "drift_1348",
+    "mba.51050",
+    "drift_1349",
+    "mbb.51070",
+    "drift_1350",
+    "mbb.51090",
+    "drift_1351",
+    "lsd.51105",
+    "drift_1352",
+    "mdv.51107",
+    "drift_1353",
+    "bpv.51108",
+    "drift_1354",
+    "qd.51110",
+    "drift_1355",
+    "mbb.51130",
+    "drift_1356",
+    "mbb.51150",
+    "drift_1357",
+    "mba.51170",
+    "drift_1358",
+    "mba.51190",
+    "drift_1359",
+    "lsf.51205",
+    "drift_1360",
+    "mdh.51207",
+    "drift_1361",
+    "bph.51208",
+    "drift_1362",
+    "qf.51210",
+    "drift_1363",
+    "mba.51230",
+    "drift_1364",
+    "mba.51250",
+    "drift_1365",
+    "mbb.51270",
+    "drift_1366",
+    "mbb.51290",
+    "drift_1367",
+    "vvsa.51301",
+    "drift_1368",
+    "bpmbv.51303",
+    "drift_1369",
+    "lsd.51305",
+    "drift_1370",
+    "mdv.51307",
+    "drift_1371",
+    "bpv.51308",
+    "drift_1372",
+    "qd.51310",
+    "drift_1373",
+    "mbb.51330",
+    "drift_1374",
+    "mbb.51350",
+    "drift_1375",
+    "mba.51370",
+    "drift_1376",
+    "mba.51390",
+    "drift_1377",
+    "qe.51402",
+    "drift_1378",
+    "lsf.51405",
+    "drift_1379",
+    "mdh.51407",
+    "drift_1380",
+    "bph.51408",
+    "drift_1381",
+    "qf.51410",
+    "drift_1382",
+    "bctdc.51454",
+    "drift_1383",
+    "bctdc.51456",
+    "drift_1384",
+    "bctfs.51458",
+    "drift_1385",
+    "mbb.51470",
+    "drift_1386",
+    "mbb.51490",
+    "drift_1387",
+    "bpmbv.51503",
+    "drift_1388",
+    "lsd.51505",
+    "drift_1389",
+    "mdv.51507",
+    "drift_1390",
+    "bpv.51508",
+    "drift_1391",
+    "qd.51510",
+    "drift_1392",
+    "mbb.51530",
+    "drift_1393",
+    "mbb.51550",
+    "drift_1394",
+    "mba.51570",
+    "drift_1395",
+    "mba.51590",
+    "drift_1396",
+    "bpce.51604",
+    "drift_1397",
+    "mdha.51606",
+    "drift_1398",
+    "qfa.51610",
+    "drift_1399",
+    "bsrta.51631",
+    "drift_1400",
+    "mdhw.51632",
+    "drift_1401",
+    "bgiha.51634",
+    "mdhw.51634",
+    "drift_1402",
+    "mdhw.51637",
+    "drift_1403",
+    "bwsrc.51637",
+    "drift_1404",
+    "bwsrc.51638",
+    "bwsd.51639",
+    "drift_1405",
+    "tcxhw.51651",
+    "drift_1406",
+    "tecs.51652",
+    "drift_1407",
+    "mdvw.51672",
+    "drift_1408",
+    "bgiva.51674",
+    "mdvw.51674",
+    "drift_1409",
+    "mdvw.51677",
+    "drift_1410",
+    "vvsa.51678",
+    "drift_1411",
+    "vvsa.51697",
+    "drift_1412",
+    "mkdvb.51698",
+    "drift_1413",
+    "mdv.51707",
+    "drift_1414",
+    "bpv.51708",
+    "drift_1415",
+    "qd.51710",
+    "drift_1416",
+    "mkdva.51731",
+    "drift_1417",
+    "mkdvb.51735",
+    "drift_1418",
+    "vvsb.51740",
+    "drift_1419",
+    "mkdha.51751",
+    "drift_1420",
+    "mkdha.51754",
+    "drift_1421",
+    "mkdhb.51757",
+    "drift_1422",
+    "vvsb.51759",
+    "drift_1423",
+    "xrp.51779",
+    "drift_1424",
+    "xrp.51791",
+    "drift_1425",
+    "bshv.51793",
+    "drift_1426",
+    "tcpc.51794",
+    "drift_1427",
+    "tqcd.51795",
+    "drift_1428",
+    "tacw.51797",
+    "drift_1429",
+    "tecs.51799",
+    "drift_1430",
+    "qfa.51810",
+    "drift_1431",
+    "mdhd.51832",
+    "drift_1432",
+    "bpce.51833",
+    "drift_1433",
+    "btv.51858",
+    "drift_1434",
+    "vvsl.51859",
+    "drift_1435",
+    "tidvg.51872",
+    "drift_1436",
+    "tmadi.51896",
+    "drift_1437",
+    "vvsa.51898",
+    "drift_1438",
+    "tmadi.51901",
+    "drift_1439",
+    "qd.51910",
+    "drift_1440",
+    "mdv.51920",
+    "drift_1441",
+    "bpv.51931",
+    "drift_1442",
+    "tcsm.51932",
+    "drift_1443",
+    "xrp.51991",
+    "drift_1444",
+    "xrp.51993",
+    "drift_1445",
+    "tqcd.51997",
+    "drift_1446",
+    "tacw.51998",
+    "drift_1447",
+    "bpmbh.51999",
+    "drift_1448",
+    "loen.52002",
+    "drift_1449",
+    "lsf.52005",
+    "drift_1450",
+    "mdh.52007",
+    "drift_1451",
+    "bph.52008",
+    "drift_1452",
+    "qf.52010",
+    "drift_1453",
+    "mba.52030",
+    "drift_1454",
+    "mba.52050",
+    "drift_1455",
+    "mbb.52070",
+    "drift_1456",
+    "mbb.52090",
+    "drift_1457",
+    "mdv.52107",
+    "drift_1458",
+    "bpv.52108",
+    "drift_1459",
+    "qd.52110",
+    "drift_1460",
+    "mbb.52130",
+    "drift_1461",
+    "brsf.52140",
+    "drift_1462",
+    "mbb.52150",
+    "drift_1463",
+    "bwsd.52171",
+    "drift_1464",
+    "brsc.52191",
+    "drift_1465",
+    "tal.52196",
+    "drift_1466",
+    "xrph.52202",
+    "drift_1467",
+    "mdh.52207",
+    "drift_1468",
+    "bph.52208",
+    "drift_1469",
+    "qf.52210",
+    "drift_1470",
+    "mba.52230",
+    "drift_1471",
+    "mba.52250",
+    "drift_1472",
+    "mbb.52270",
+    "drift_1473",
+    "mbb.52290",
+    "drift_1474",
+    "vvsa.52301",
+    "drift_1475",
+    "lsd.52305",
+    "drift_1476",
+    "mdv.52307",
+    "drift_1477",
+    "bpv.52308",
+    "drift_1478",
+    "qd.52310",
+    "drift_1479",
+    "mbb.52330",
+    "drift_1480",
+    "mbb.52350",
+    "drift_1481",
+    "mba.52370",
+    "drift_1482",
+    "mba.52390",
+    "drift_1483",
+    "lse.52402",
+    "drift_1484",
+    "lsf.52405",
+    "drift_1485",
+    "mdh.52407",
+    "drift_1486",
+    "bph.52408",
+    "drift_1487",
+    "qf.52410",
+    "drift_1488",
+    "mba.52430",
+    "drift_1489",
+    "mba.52450",
+    "drift_1490",
+    "mbb.52470",
+    "drift_1491",
+    "mbb.52490",
+    "drift_1492",
+    "lsd.52505",
+    "drift_1493",
+    "mdv.52507",
+    "drift_1494",
+    "bpv.52508",
+    "drift_1495",
+    "qd.52510",
+    "drift_1496",
+    "mbb.52530",
+    "drift_1497",
+    "mbb.52550",
+    "drift_1498",
+    "mba.52570",
+    "drift_1499",
+    "mba.52590",
+    "drift_1500",
+    "lof.52602",
+    "drift_1501",
+    "lsf.52605",
+    "drift_1502",
+    "mdh.52607",
+    "drift_1503",
+    "bph.52608",
+    "drift_1504",
+    "qf.52610",
+    "drift_1505",
+    "mba.52630",
+    "drift_1506",
+    "mba.52650",
+    "drift_1507",
+    "mbb.52670",
+    "drift_1508",
+    "mbb.52690",
+    "drift_1509",
+    "lod.52702",
+    "drift_1510",
+    "lsd.52705",
+    "drift_1511",
+    "mdv.52707",
+    "drift_1512",
+    "bpv.52708",
+    "drift_1513",
+    "qd.52710",
+    "drift_1514",
+    "mbb.52730",
+    "drift_1515",
+    "mbb.52750",
+    "drift_1516",
+    "mba.52770",
+    "drift_1517",
+    "mba.52790",
+    "drift_1518",
+    "lof.52802",
+    "drift_1519",
+    "mdh.52807",
+    "drift_1520",
+    "bph.52808",
+    "drift_1521",
+    "qf.52810",
+    "drift_1522",
+    "mba.52830",
+    "drift_1523",
+    "mba.52850",
+    "drift_1524",
+    "mbb.52870",
+    "drift_1525",
+    "mbb.52890",
+    "drift_1526",
+    "lqsa.52902",
+    "drift_1527",
+    "mdv.52907",
+    "drift_1528",
+    "bpv.52908",
+    "drift_1529",
+    "qd.52910",
+    "drift_1530",
+    "mbb.52930",
+    "drift_1531",
+    "mbb.52950",
+    "drift_1532",
+    "mba.52970",
+    "drift_1533",
+    "mba.52990",
+    "drift_1534",
+    "lof.53002",
+    "drift_1535",
+    "mdh.53007",
+    "drift_1536",
+    "bph.53008",
+    "drift_1537",
+    "qf.53010",
+    "drift_1538",
+    "mba.53030",
+    "drift_1539",
+    "mba.53050",
+    "drift_1540",
+    "mbb.53070",
+    "drift_1541",
+    "mbb.53090",
+    "drift_1542",
+    "vvsa.53105",
+    "drift_1543",
+    "mdv.53107",
+    "drift_1544",
+    "bpv.53108",
+    "drift_1545",
+    "qd.53110",
+    "drift_1546",
+    "mbb.53130",
+    "drift_1547",
+    "mbb.53150",
+    "drift_1548",
+    "mba.53170",
+    "drift_1549",
+    "mba.53190",
+    "drift_1550",
+    "lsf.53205",
+    "drift_1551",
+    "mdh.53207",
+    "drift_1552",
+    "bph.53208",
+    "drift_1553",
+    "qf.53210",
+    "drift_1554",
+    "mba.53230",
+    "drift_1555",
+    "mba.53250",
+    "drift_1556",
+    "mbb.53270",
+    "drift_1557",
+    "mbb.53290",
+    "drift_1558",
+    "lod.53302",
+    "drift_1559",
+    "mdv.53307",
+    "drift_1560",
+    "bpv.53308",
+    "drift_1561",
+    "qd.53310",
+    "drift_1562",
+    "mbb.53330",
+    "drift_1563",
+    "mbb.53350",
+    "drift_1564",
+    "mba.53370",
+    "drift_1565",
+    "mba.53390",
+    "drift_1566",
+    "qecd.53402",
+    "drift_1567",
+    "mdh.53407",
+    "drift_1568",
+    "bph.53408",
+    "drift_1569",
+    "qf.53410",
+    "drift_1570",
+    "mba.53430",
+    "drift_1571",
+    "mba.53450",
+    "drift_1572",
+    "mbb.53470",
+    "drift_1573",
+    "mbb.53490",
+    "drift_1574",
+    "lod.53502",
+    "drift_1575",
+    "lsd.53505",
+    "drift_1576",
+    "mdv.53507",
+    "drift_1577",
+    "bpv.53508",
+    "drift_1578",
+    "qd.53510",
+    "drift_1579",
+    "mbb.53530",
+    "drift_1580",
+    "mbb.53550",
+    "drift_1581",
+    "mba.53570",
+    "drift_1582",
+    "mba.53590",
+    "drift_1583",
+    "loen.53602",
+    "drift_1584",
+    "lsf.53605",
+    "drift_1585",
+    "mdh.53607",
+    "drift_1586",
+    "bph.53608",
+    "drift_1587",
+    "qf.60010",
+    "drift_1588",
+    "mba.60030",
+    "drift_1589",
+    "mba.60050",
+    "drift_1590",
+    "mbb.60070",
+    "drift_1591",
+    "mbb.60090",
+    "drift_1592",
+    "vvsa.60103",
+    "drift_1593",
+    "lsd.60105",
+    "drift_1594",
+    "mdv.60107",
+    "drift_1595",
+    "bpv.60108",
+    "drift_1596",
+    "qd.60110",
+    "drift_1597",
+    "mbb.60130",
+    "drift_1598",
+    "mbb.60150",
+    "drift_1599",
+    "mba.60170",
+    "drift_1600",
+    "mba.60190",
+    "drift_1601",
+    "lsf.60205",
+    "drift_1602",
+    "mdh.60207",
+    "drift_1603",
+    "bph.60208",
+    "drift_1604",
+    "qf.60210",
+    "drift_1605",
+    "mba.60230",
+    "drift_1606",
+    "mba.60250",
+    "drift_1607",
+    "mbb.60270",
+    "drift_1608",
+    "mbb.60290",
+    "drift_1609",
+    "qe.60302",
+    "drift_1610",
+    "lsd.60305",
+    "drift_1611",
+    "mdv.60307",
+    "drift_1612",
+    "bpv.60308",
+    "drift_1613",
+    "qd.60310",
+    "drift_1614",
+    "mbb.60330",
+    "drift_1615",
+    "mbb.60350",
+    "drift_1616",
+    "mba.60370",
+    "drift_1617",
+    "mba.60390",
+    "drift_1618",
+    "qe.60402",
+    "drift_1619",
+    "mdh.60407",
+    "drift_1620",
+    "bph.60408",
+    "drift_1621",
+    "qf.60410",
+    "drift_1622",
+    "mba.60430",
+    "drift_1623",
+    "mba.60450",
+    "drift_1624",
+    "mbb.60470",
+    "drift_1625",
+    "mbb.60490",
+    "drift_1626",
+    "qe.60502",
+    "drift_1627",
+    "mdv.60507",
+    "drift_1628",
+    "bpv.60508",
+    "drift_1629",
+    "qd.60510",
+    "drift_1630",
+    "mbb.60530",
+    "drift_1631",
+    "mbb.60550",
+    "drift_1632",
+    "mba.60570",
+    "drift_1633",
+    "mba.60590",
+    "drift_1634",
+    "qe.60602",
+    "drift_1635",
+    "mdh.60607",
+    "drift_1636",
+    "bph.60608",
+    "drift_1637",
+    "qf.60610",
+    "drift_1638",
+    "mba.60630",
+    "drift_1639",
+    "mba.60650",
+    "drift_1640",
+    "mbb.60670",
+    "drift_1641",
+    "mbb.60690",
+    "drift_1642",
+    "lod.60702",
+    "drift_1643",
+    "vvsa.60705",
+    "drift_1644",
+    "mdv.60707",
+    "drift_1645",
+    "bpv.60708",
+    "drift_1646",
+    "qd.60710",
+    "drift_1647",
+    "mbb.60730",
+    "drift_1648",
+    "mbb.60750",
+    "drift_1649",
+    "mba.60770",
+    "drift_1650",
+    "mba.60790",
+    "drift_1651",
+    "lof.60802",
+    "drift_1652",
+    "lsf.60805",
+    "drift_1653",
+    "mdh.60807",
+    "drift_1654",
+    "bph.60808",
+    "drift_1655",
+    "qf.60810",
+    "drift_1656",
+    "mba.60830",
+    "drift_1657",
+    "mba.60850",
+    "drift_1658",
+    "mbb.60870",
+    "drift_1659",
+    "mbb.60890",
+    "drift_1660",
+    "bctfs.60903",
+    "drift_1661",
+    "mdv.60907",
+    "drift_1662",
+    "bpv.60908",
+    "drift_1663",
+    "qd.60910",
+    "drift_1664",
+    "mbb.60930",
+    "drift_1665",
+    "mbb.60950",
+    "drift_1666",
+    "mba.60970",
+    "drift_1667",
+    "mba.60990",
+    "drift_1668",
+    "bbsr.61001",
+    "btv.61003",
+    "drift_1669",
+    "mdh.61007",
+    "drift_1670",
+    "bph.61008",
+    "drift_1671",
+    "qf.61010",
+    "drift_1672",
+    "mba.61030",
+    "drift_1673",
+    "mba.61050",
+    "drift_1674",
+    "mbb.61070",
+    "drift_1675",
+    "mbb.61090",
+    "drift_1676",
+    "lsd.61105",
+    "drift_1677",
+    "mdv.61107",
+    "drift_1678",
+    "bpcn.61108",
+    "drift_1679",
+    "qd.61110",
+    "drift_1680",
+    "mbb.61130",
+    "drift_1681",
+    "mbb.61150",
+    "drift_1682",
+    "mba.61170",
+    "drift_1683",
+    "mba.61190",
+    "drift_1684",
+    "lsf.61205",
+    "drift_1685",
+    "mdh.61207",
+    "drift_1686",
+    "bph.61208",
+    "drift_1687",
+    "qf.61210",
+    "drift_1688",
+    "mba.61230",
+    "drift_1689",
+    "mba.61250",
+    "drift_1690",
+    "mbb.61270",
+    "drift_1691",
+    "mbb.61290",
+    "drift_1692",
+    "vvsa.61301",
+    "drift_1693",
+    "mpsv.61303",
+    "drift_1694",
+    "lsd.61305",
+    "drift_1695",
+    "mdv.61307",
+    "drift_1696",
+    "bpcn.61308",
+    "drift_1697",
+    "qd.61310",
+    "drift_1698",
+    "mbb.61330",
+    "drift_1699",
+    "mbb.61350",
+    "drift_1700",
+    "mba.61370",
+    "drift_1701",
+    "mba.61390",
+    "drift_1702",
+    "mpsh.61402",
+    "drift_1703",
+    "lsf.61405",
+    "drift_1704",
+    "mdh.61407",
+    "drift_1705",
+    "bph.61408",
+    "drift_1706",
+    "qf.61410",
+    "drift_1707",
+    "vvfa.61459",
+    "drift_1708",
+    "mbb.61470",
+    "drift_1709",
+    "mbb.61490",
+    "drift_1710",
+    "mpsv.61503",
+    "drift_1711",
+    "lsd.61505",
+    "drift_1712",
+    "mdv.61507",
+    "drift_1713",
+    "bpv.61508",
+    "drift_1714",
+    "qd.61510",
+    "drift_1715",
+    "mbb.61530",
+    "drift_1716",
+    "mbb.61550",
+    "drift_1717",
+    "mba.61570",
+    "drift_1718",
+    "mba.61590",
+    "drift_1719",
+    "mdh.61607",
+    "drift_1720",
+    "bph.61608",
+    "drift_1721",
+    "qf.61610",
+    "drift_1722",
+    "vvsb.61620",
+    "drift_1723",
+    "mke.61631",
+    "drift_1724",
+    "mke.61634",
+    "drift_1725",
+    "mke.61637",
+    "drift_1726",
+    "vvsb.61654",
+    "drift_1727",
+    "mplh.61655",
+    "drift_1728",
+    "vvfa.61695",
+    "drift_1729",
+    "mdva.61703",
+    "drift_1730",
+    "bpce.61705",
+    "drift_1731",
+    "qda.61710",
+    "drift_1732",
+    "vvsb.61731",
+    "drift_1733",
+    "vcbn.61732",
+    "drift_1734",
+    "bpmca.61736",
+    "drift_1735",
+    "acfcah.61738",
+    "drift_1736",
+    "acfcah.61739",
+    "drift_1737",
+    "vcbn.61752",
+    "drift_1738",
+    "vvsb.61757",
+    "drift_1739",
+    "btve.61759",
+    "drift_1740",
+    "tpsg.61760",
+    "drift_1741",
+    "tpsg.61773",
+    "drift_1742",
+    "tpsg.61776",
+    "drift_1743",
+    "mst.61779",
+    "drift_1744",
+    "vebx.61793",
+    "drift_1745",
+    "mst.61794",
+    "drift_1746",
+    "btve.61798",
+    "drift_1747",
+    "vvse.61799",
+    "drift_1748",
+    "vvfb.61801",
+    "drift_1749",
+    "bpce.61804",
+    "drift_1750",
+    "mdha.61805",
+    "drift_1751",
+    "qspl.61809",
+    "drift_1752",
+    "qfa.61810",
+    "drift_1753",
+    "btve.61831",
+    "drift_1754",
+    "mse.61832",
+    "drift_1755",
+    "vebx.61836",
+    "drift_1756",
+    "mse.61837",
+    "drift_1757",
+    "vebx.61851",
+    "drift_1758",
+    "mse.61852",
+    "drift_1759",
+    "vebx.61856",
+    "drift_1760",
+    "mse.61857",
+    "drift_1761",
+    "vebx.61871",
+    "drift_1762",
+    "mse.61872",
+    "drift_1763",
+    "btve.61876",
+    "vetb.61876",
+    "drift_1764",
+    "vvfb.61877",
+    "drift_1765",
+    "vvsf.61880",
+    "drift_1766",
+    "vvsb.61903",
+    "drift_1767",
+    "qda.61910",
+    "drift_1768",
+    "bpce.61931",
+    "drift_1769",
+    "mdva.61932",
+    "drift_1770",
+    "vvfa.61957",
+    "drift_1771",
+    "mplh.61996",
+    "drift_1772",
+    "lsf.62005",
+    "drift_1773",
+    "mdh.62007",
+    "drift_1774",
+    "bph.62008",
+    "drift_1775",
+    "qf.62010",
+    "drift_1776",
+    "mba.62030",
+    "drift_1777",
+    "mba.62050",
+    "drift_1778",
+    "mbb.62070",
+    "drift_1779",
+    "mbb.62090",
+    "drift_1780",
+    "mpsv.62103",
+    "drift_1781",
+    "mdv.62107",
+    "drift_1782",
+    "bpv.62108",
+    "drift_1783",
+    "qd.62110",
+    "drift_1784",
+    "mbb.62130",
+    "drift_1785",
+    "mbb.62150",
+    "drift_1786",
+    "mpsh.62199",
+    "drift_1787",
+    "lof.62202",
+    "drift_1788",
+    "mdh.62207",
+    "drift_1789",
+    "bph.62208",
+    "drift_1790",
+    "qf.62210",
+    "drift_1791",
+    "mba.62230",
+    "drift_1792",
+    "mba.62250",
+    "drift_1793",
+    "mbb.62270",
+    "drift_1794",
+    "mbb.62290",
+    "drift_1795",
+    "vvsa.62301",
+    "drift_1796",
+    "mpsv.62303",
+    "drift_1797",
+    "lsd.62305",
+    "drift_1798",
+    "mdv.62307",
+    "drift_1799",
+    "bpv.62308",
+    "drift_1800",
+    "qd.62310",
+    "drift_1801",
+    "mbb.62330",
+    "drift_1802",
+    "mbb.62350",
+    "drift_1803",
+    "mba.62370",
+    "drift_1804",
+    "mba.62390",
+    "drift_1805",
+    "lse.62402",
+    "drift_1806",
+    "lsf.62405",
+    "drift_1807",
+    "mdh.62407",
+    "drift_1808",
+    "bph.62408",
+    "drift_1809",
+    "qf.62410",
+    "drift_1810",
+    "mba.62430",
+    "drift_1811",
+    "mba.62450",
+    "drift_1812",
+    "mbb.62470",
+    "drift_1813",
+    "mbb.62490",
+    "drift_1814",
+    "lsd.62505",
+    "drift_1815",
+    "mdv.62507",
+    "drift_1816",
+    "bpv.62508",
+    "drift_1817",
+    "qd.62510",
+    "drift_1818",
+    "mbb.62530",
+    "drift_1819",
+    "mbb.62550",
+    "drift_1820",
+    "mba.62570",
+    "drift_1821",
+    "mba.62590",
+    "drift_1822",
+    "lof.62602",
+    "drift_1823",
+    "lsf.62605",
+    "drift_1824",
+    "mdh.62607",
+    "drift_1825",
+    "bph.62608",
+    "drift_1826",
+    "qf.62610",
+    "drift_1827",
+    "mba.62630",
+    "drift_1828",
+    "mba.62650",
+    "drift_1829",
+    "mbb.62670",
+    "drift_1830",
+    "mbb.62690",
+    "drift_1831",
+    "lod.62702",
+    "drift_1832",
+    "lsd.62705",
+    "drift_1833",
+    "mdv.62707",
+    "drift_1834",
+    "bpv.62708",
+    "drift_1835",
+    "qd.62710",
+    "drift_1836",
+    "mbb.62730",
+    "drift_1837",
+    "mbb.62750",
+    "drift_1838",
+    "mba.62770",
+    "drift_1839",
+    "mba.62790",
+    "drift_1840",
+    "lof.62802",
+    "drift_1841",
+    "mdh.62807",
+    "drift_1842",
+    "bph.62808",
+    "drift_1843",
+    "qf.62810",
+    "drift_1844",
+    "mba.62830",
+    "drift_1845",
+    "mba.62850",
+    "drift_1846",
+    "mbb.62870",
+    "drift_1847",
+    "mbb.62890",
+    "drift_1848",
+    "lqsa.62902",
+    "drift_1849",
+    "mdv.62907",
+    "drift_1850",
+    "bpv.62908",
+    "drift_1851",
+    "qd.62910",
+    "drift_1852",
+    "mbb.62930",
+    "drift_1853",
+    "mbb.62950",
+    "drift_1854",
+    "mba.62970",
+    "drift_1855",
+    "mba.62990",
+    "drift_1856",
+    "loe.63002",
+    "drift_1857",
+    "mdh.63007",
+    "drift_1858",
+    "bph.63008",
+    "drift_1859",
+    "qf.63010",
+    "drift_1860",
+    "mba.63030",
+    "drift_1861",
+    "mba.63050",
+    "drift_1862",
+    "mbb.63070",
+    "drift_1863",
+    "mbb.63090",
+    "drift_1864",
+    "vvsa.63105",
+    "drift_1865",
+    "mdv.63107",
+    "drift_1866",
+    "bpv.63108",
+    "drift_1867",
+    "qd.63110",
+    "drift_1868",
+    "mbb.63130",
+    "drift_1869",
+    "mbb.63150",
+    "drift_1870",
+    "mba.63170",
+    "drift_1871",
+    "mba.63190",
+    "drift_1872",
+    "lsf.63205",
+    "drift_1873",
+    "mdh.63207",
+    "drift_1874",
+    "bph.63208",
+    "drift_1875",
+    "qf.63210",
+    "drift_1876",
+    "mba.63230",
+    "drift_1877",
+    "mba.63250",
+    "drift_1878",
+    "mbb.63270",
+    "drift_1879",
+    "mbb.63290",
+    "drift_1880",
+    "lod.63302",
+    "drift_1881",
+    "mdv.63307",
+    "drift_1882",
+    "bpv.63308",
+    "drift_1883",
+    "qd.63310",
+    "drift_1884",
+    "mbb.63330",
+    "drift_1885",
+    "mbb.63350",
+    "drift_1886",
+    "mba.63370",
+    "drift_1887",
+    "mba.63390",
+    "drift_1888",
+    "mdh.63407",
+    "drift_1889",
+    "bph.63408",
+    "drift_1890",
+    "qf.63410",
+    "drift_1891",
+    "mba.63430",
+    "drift_1892",
+    "mba.63450",
+    "drift_1893",
+    "mbb.63470",
+    "drift_1894",
+    "mbb.63490",
+    "drift_1895",
+    "lod.63502",
+    "drift_1896",
+    "lsd.63505",
+    "drift_1897",
+    "mdv.63507",
+    "drift_1898",
+    "bpv.63508",
+    "drift_1899",
+    "qd.63510",
+    "drift_1900",
+    "mbb.63530",
+    "drift_1901",
+    "mbb.63550",
+    "drift_1902",
+    "mba.63570",
+    "drift_1903",
+    "mba.63590",
+    "drift_1904",
+    "loe.63602",
+    "drift_1905",
+    "lsf.63605",
+    "drift_1906",
+    "mdh.63607",
+    "drift_1907",
+    "bph.63608",
+    "drift_1908",
+    "end.10010"
+   ],
+   "config": {
+    "XTRACK_MULTIPOLE_NO_SYNRAD": true,
+    "XFIELDS_BB3D_NO_BEAMSTR": true,
+    "XFIELDS_BB3D_NO_BHABHA": true,
+    "XTRACK_GLOBAL_XY_LIMIT": 1.0
+   },
+   "_extra_config": {
+    "skip_end_turn_actions": false,
+    "reset_s_at_end_turn": true,
+    "matrix_responsiveness_tol": 1e-15,
+    "matrix_stability_tol": 0.002,
+    "dt_update_time_dependent_vars": 0.0,
+    "_t_last_update_time_dependent_vars": null,
+    "_radiation_model": null,
+    "_beamstrahlung_model": null,
+    "_bhabha_model": null,
+    "_spin_model": null,
+    "_needs_rng": false,
+    "enable_time_dependent_vars": false,
+    "twiss_default": {},
+    "steering_monitors_x": null,
+    "steering_monitors_y": null,
+    "steering_correctors_x": null,
+    "steering_correctors_y": null,
+    "corrector_limits_x": null,
+    "corrector_limits_y": null
+   },
+   "particle_ref": {
+    "_rng_s3": [
+     0
+    ],
+    "px": [
+     0.0
+    ],
+    "s": [
+     0.0
+    ],
+    "start_tracking_at_element": -1,
+    "anomalous_magnetic_moment": [
+     0.0
+    ],
+    "spin_z": [
+     0.0
+    ],
+    "t_sim": 2.306948900289559e-05,
+    "particle_id": [
+     0
+    ],
+    "y": [
+     0.0
+    ],
+    "charge_ratio": [
+     1.0
+    ],
+    "zeta": [
+     0.0
+    ],
+    "x": [
+     0.0
+    ],
+    "ax": [
+     0.0
+    ],
+    "weight": [
+     1.0
+    ],
+    "state": [
+     1
+    ],
+    "at_turn": [
+     0
+    ],
+    "_rng_s1": [
+     0
+    ],
+    "q0": 1.0,
+    "py": [
+     0.0
+    ],
+    "chi": [
+     1.0
+    ],
+    "mass0": 938272088.16,
+    "parent_particle_id": [
+     0
+    ],
+    "pdg_id": [
+     0
+    ],
+    "at_element": [
+     0
+    ],
+    "_rng_s4": [
+     0
+    ],
+    "spin_x": [
+     0.0
+    ],
+    "_rng_s2": [
+     0
+    ],
+    "spin_y": [
+     0.0
+    ],
+    "ay": [
+     0.0
+    ],
+    "delta": [
+     0.0
+    ],
+    "ptau": [
+     -2.220446049250313e-16
+    ],
+    "rvv": [
+     1.0
+    ],
+    "rpp": [
+     1.0
+    ],
+    "p0c": [
+     25920000000.0
+    ],
+    "beta0": [
+     0.9993454677474586
+    ],
+    "gamma0": [
+     27.643342389704696
+    ]
+   },
+   "metadata": {}
+  }
+ }
+}

--- a/examples/rf_sweep.py
+++ b/examples/rf_sweep.py
@@ -25,16 +25,22 @@ path_out = Path.cwd()
 line = xt.Line.from_json(path_in / 'machines' / f'lhc_run3_b{beam}.json')
 
 line.build_tracker()
-line.optimize_for_tracking()
 
 num_particles = 2
 part = line.build_particles(delta=[-2e-4, 2e-4], x_norm=0, px_norm=0, y_norm=0, py_norm=0)
 monitor = xt.ParticlesMonitor(start_at_turn=1, stop_at_turn=num_turns, num_particles=2)
 
-rf_sweep = xc.RFSweep(line)
-rf_sweep.info(sweep=sweep, num_turns=num_turns)
 
-rf_sweep.track(sweep=sweep, num_turns=num_turns, particles=part, time=True, turn_by_turn_monitor=monitor)
+# Prepare RF sweep
+# Alternatively, just call  xc.prepare_rf_sweep(line, sweep=sweep, num_turns=num_turns)
+rf_sweep = xc.RFSweep(line)
+rf_sweep.prepare(sweep=sweep, num_turns=num_turns)  # or sweep_per_turn=sweep/num_turns
+rf_sweep.info()
+
+
+# Do the tracking
+line.track(particles=part, num_turns=num_turns, time=True, turn_by_turn_monitor=monitor)
+
 
 plt.figure(figsize=(12,8))
 plt.plot(monitor.zeta.T,monitor.delta.T)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "xcoll"
-version = "0.6.2"
+version = "0.6.3rc0"
 description = "Xsuite collimation package"
 homepage = "https://github.com/xsuite/xcoll"
 repository = "https://github.com/xsuite/xcoll"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,41 +1,50 @@
-[tool.poetry]
+[project]
 name = "xcoll"
-version = "0.6.3rc0"
+version = "0.7.0rc0"
 description = "Xsuite collimation package"
-homepage = "https://github.com/xsuite/xcoll"
-repository = "https://github.com/xsuite/xcoll"
 authors = [
-           "Frederik F. Van der Veken <frederik@cern.ch>",
-           "Simone O. Solstrand <simone.otelie.solstrand@cern.ch>",
-           "Björn Lindstrom <bjorn.lindstrom@cern.ch>",
-           "Giacomo Broggi <giacomo.broggi@cern.ch>",
-           "André Donadon Servelle <andre.donadon.servelle@cern.ch>",
-           "Dora E. Veres <dora.erzsebet.veres@cern.ch>",
-           "Despina Demetriadou <despina.demetriadou@cern.ch>",
-           "Andrey Abramov <andrey.abramov@cern.ch>",
-           "Giovanni Iadarola <giovanni.iadarola@cern.ch>"
+    {name="Frederik F. Van der Veken", email="frederik@cern.ch"},
+    {name="Simone O. Solstrand",       email="simone.otelie.solstrand@cern.ch"},
+    {name="Björn Lindstrom",           email="bjorn.lindstrom@cern.ch"},
+    {name="Giacomo Broggi",            email="giacomo.broggi@cern.ch"},
+    {name="André Donadon Servelle",    email="andre.donadon.servelle@cern.ch"},
+    {name="Dora E. Veres",             email="dora.erzsebet.veres@cern.ch"},
+    {name="Despina Demetriadou",       email="despina.demetriadou@cern.ch"},
+    {name="Andrey Abramov",            email="andrey.abramov@cern.ch"},
+    {name="Giovanni Iadarola",         email="giovanni.iadarola@cern.ch"}
 ]
 readme = "README.md"
-license = "Apache 2.0"
+license = {text="Apache-2.0"}
 exclude = ["xcoll/lib", "xcoll/config"]
 
+requires-python = ">=3.10"
 
-[tool.poetry.dependencies]
-python = ">=3.8"
-ruamel-yaml = { version = "^0.17.31", optional = true }
-numpy = ">=1.0"
-pandas = ">=1.4"
-xobjects = ">=0.5.0"
-xdeps = ">=0.10.5"
-xpart = ">=0.23.0"
-xtrack = ">=0.84.8"
+dependencies = [
+    "ruamel-yaml (>=0.17.31,<0.18.15)",
+    "numpy (>=1.0)",
+    "pandas (>=1.4)",
+    "xobjects (>=0.5.0)",
+    "xdeps (>=0.10.5)",
+    "xpart (>=0.23.0)",
+    "xtrack (>=0.84.8)",
+]
+
+[project.optional-dependencies]
+tests = ["pytest", "pytest-html", "pytest-xdist"]
+
+[project.urls]
+homepage = "https://github.com/xsuite/xcoll"
+repository = "https://github.com/xsuite/xcoll"
+documentation = "https://xsuite.readthedocs.io/"
+"Bug Tracker" = "https://github.com/xsuite/xsuite/issues"
+download = "https://pypi.python.org/pypi/xcoll"
+
+[project.entry-points.xobjects]
+include = "xcoll"
 
 [poetry.group.dev.dependencies]
 pytest = ">=7.3"
 xaux = ">=0.3.5"
-
-[tool.poetry.extras]
-tests = ["pytest", "ruamel-yaml", "pytest-html", "pytest-xdist"]
 
 [build-system]
 # Needed for pip install -e (BTW: need pip version 22)
@@ -43,10 +52,10 @@ requires = ["poetry-core>=1.0.8"]
 build-backend = "poetry.core.masonry.api"
 
 # pyproject.toml
-[tool.pytest.ini_options]
-addopts = "-ra --durations=10 --durations-min=1"
-python_functions = ["test_"]
-testpaths = [
-    "tests",
-]
+#[tool.pytest.ini_options]
+#addopts = "-ra --durations=10 --durations-min=1"
+#python_functions = ["test_"]
+#testpaths = [
+#    "tests",
+#]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xcoll"
-version = "0.6.3rc0"
+version = "0.6.3"
 description = "Xsuite collimation package"
 authors = [
     {name="Frederik F. Van der Veken", email="frederik@cern.ch"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xcoll"
-version = "0.7.0rc0"
+version = "0.6.3rc0"
 description = "Xsuite collimation package"
 authors = [
     {name="Frederik F. Van der Veken", email="frederik@cern.ch"},

--- a/tests/data/sequence_sps_q20_inj.json
+++ b/tests/data/sequence_sps_q20_inj.json
@@ -1,0 +1,1 @@
+../../examples/machines/sps_q20_inj.json

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+addopts = -ra --durations=10 --durations-min=1 --html='pytest_results.html'
+generate_report_on_test = True
+render_collapsed = all

--- a/tests/run_all.sh
+++ b/tests/run_all.sh
@@ -13,7 +13,7 @@ then
     xsuite-prebuild r
     # "xsuite-prebuild c" to remove kernels
     echo "done."
-    pytest -n 10 -vv --html="pytest_results.html" --self-contained-html
+    pytest -n 10 -vv
 else
     echo "Not all tests are verified. Aborting."
     exit 1

--- a/tests/test_rf_sweep.py
+++ b/tests/test_rf_sweep.py
@@ -14,12 +14,18 @@ from xobjects.test_helpers import for_all_test_contexts
 path = Path(__file__).parent / 'data'
 
 @for_all_test_contexts
-@pytest.mark.parametrize("sweep, beam", [[-300, 1], [300, 2]],
-                         ids=["DP pos", "DP neg"])
+@pytest.mark.parametrize("sweep, beam", [[-300, 1], [300, 2], [3500, 3]],
+                         ids=["DP pos LHC", "DP neg LHC", "DP neg SPS"])
 def test_rf_sweep(sweep, beam, test_context):
     num_turns = 6000
     num_particles = 5
-    line = xt.Line.from_json(path / f'sequence_lhc_run3_b{beam}.json')
+    if beam == 3:
+        line = xt.load(path / f'sequence_sps_q20_inj.json')['sps']
+        line.insert('markkk', xt.Marker(), at=2822)
+        tt_c = line.get_table().rows['ac.*']
+        assert 'ThickSliceCavity' in tt_c.element_type
+    else:
+        line = xt.load(path / f'sequence_lhc_run3_b{beam}.json')
 
     line.build_tracker()
 

--- a/tests/test_rf_sweep.py
+++ b/tests/test_rf_sweep.py
@@ -27,8 +27,10 @@ def test_rf_sweep(sweep, beam, test_context):
                                 x_norm=0, px_norm=0, y_norm=0, py_norm=0)
 
     rf_sweep = xc.RFSweep(line)
+    rf_sweep.prepare(sweep_per_turn=sweep/num_turns)
+    rf_sweep.info()
     # This sweep is 3.5 buckets, so check that all particles are at least 3 buckets away
-    rf_sweep.track(sweep=sweep, num_turns=num_turns, particles=part)
+    line.track(particles=part, num_turns=num_turns)
 
     # negative sweep => positive off-momentum etc
     if sweep < 0:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@
 from xcoll import __version__
 
 def test_version():
-    assert __version__ == '0.6.2'
+    assert __version__ == '0.6.3rc0'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@
 from xcoll import __version__
 
 def test_version():
-    assert __version__ == '0.6.3rc0'
+    assert __version__ == '0.6.3'

--- a/xcoll/__init__.py
+++ b/xcoll/__init__.py
@@ -11,7 +11,7 @@ from .beam_elements import BlackAbsorber, BlackCrystal, TransparentCollimator, T
 from .scattering_routines.everest import materials, Material, CrystalMaterial
 from .colldb import CollimatorDatabase
 from .interaction_record import InteractionRecord
-from .rf_sweep import RFSweep
+from .rf_sweep import RFSweep, prepare_rf_sweep
 from .lossmap import LossMap, MultiLossMap
 
 

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -12,5 +12,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ======================
 # Do not change
 # ======================
-__version__ = '0.6.3rc0'
+__version__ = '0.6.3'
 # ======================

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -12,5 +12,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ======================
 # Do not change
 # ======================
-__version__ = '0.6.2'
+__version__ = '0.6.3rc0'
 # ======================

--- a/xcoll/prebuild_kernels/__init__.py
+++ b/xcoll/prebuild_kernels/__init__.py
@@ -1,0 +1,7 @@
+# copyright ############################### #
+# This file is part of the Xcoll package.   #
+# Copyright (c) CERN, 2025.                 #
+# ######################################### #
+
+from .elements import DEFAULT_XCOLL_ELEMENTS
+from .element_inits import XCOLL_ELEMENTS_INIT_DEFAULTS

--- a/xcoll/prebuild_kernels/element_inits.py
+++ b/xcoll/prebuild_kernels/element_inits.py
@@ -1,0 +1,6 @@
+# copyright ############################### #
+# This file is part of the Xcoll package.   #
+# Copyright (c) CERN, 2025.                 #
+# ######################################### #
+
+XCOLL_ELEMENTS_INIT_DEFAULTS = {}

--- a/xcoll/prebuild_kernels/elements.py
+++ b/xcoll/prebuild_kernels/elements.py
@@ -1,0 +1,20 @@
+# copyright ############################### #
+# This file is part of the Xcoll package.   #
+# Copyright (c) CERN, 2025.                 #
+# ######################################### #
+
+from ..beam_elements import *
+
+
+DEFAULT_XCOLL_ELEMENTS = [
+    BlackAbsorber,
+    BlackCrystal,
+    TransparentCollimator,
+    TransparentCrystal,
+    EverestBlock,
+    EverestCollimator,
+    EverestCrystal,
+    BlowUp,
+    # ParticleStatsMonitor,
+    EmittanceMonitor
+]

--- a/xcoll/rf_sweep.py
+++ b/xcoll/rf_sweep.py
@@ -50,6 +50,7 @@ class RFSweep:
             raise ValueError("Either `sweep` or `sweep_per_turn` must be provided.")
         self._get_cavity_data(self.sweep_per_turn)
         self._install_zeta_shift()
+        self.tw = self.line.twiss()
         self.reset() # Initialize rf_sweep_df
         self.env['rf_sweep'].dzeta = f"{self.L} * rf_sweep_df / ({self.f_RF} + rf_sweep_df)"
         for cavs in self.cavities:
@@ -66,7 +67,6 @@ class RFSweep:
     def reset(self):
         if self.sweep_per_turn is None:
             raise ValueError("RFSweep not prepared. Call `prepare` first.")
-        self.tw = self.line.twiss()
         t_turn = self.tw.T_rev0
         current_time = self.env['t_turn_s']
         if current_time == 0:

--- a/xcoll/rf_sweep.py
+++ b/xcoll/rf_sweep.py
@@ -48,7 +48,7 @@ class RFSweep:
             self.sweep_per_turn = sweep / num_turns
         else:
             raise ValueError("Either `sweep` or `sweep_per_turn` must be provided.")
-        self._get_base_frequency(sweep)
+        self._get_cavity_data(self.sweep_per_turn)
         self._install_zeta_shift()
         self.reset() # Initialize rf_sweep_df
         self.env['rf_sweep'].dzeta = f"{self.L} * rf_sweep_df / ({self.f_RF} + rf_sweep_df)"
@@ -58,7 +58,7 @@ class RFSweep:
                 if scale_factor == 1:
                     self.env.ref[cav].frequency += self.env.ref["rf_sweep_df"]
                 else:
-                    self.env.ref[cav].frequency += {scale_factor} * self.env.ref["rf_sweep_df"]
+                    self.env.ref[cav].frequency += scale_factor * self.env.ref["rf_sweep_df"]
         self.line.enable_time_dependent_vars = True
         print("Enabled time-dependent variables in the line.")
 
@@ -70,9 +70,9 @@ class RFSweep:
         t_turn = self.tw.T_rev0
         current_time = self.env['t_turn_s']
         if current_time == 0:
-            self.env['rf_sweep_df'] = f"t_turn_s / {t_turn} * {self.sweep_per_turn}"
+            self.env['rf_sweep_df'] = f"(t_turn_s + {t_turn}) / {t_turn} * {self.sweep_per_turn}"
         else:
-            self.env['rf_sweep_df'] = f"(t_turn_s - {current_time}) / {t_turn} * {self.sweep_per_turn}"
+            self.env['rf_sweep_df'] = f"(t_turn_s - {current_time} + {t_turn}) / {t_turn} * {self.sweep_per_turn}"
 
 
     def info(self, sweep=None, num_turns=None):
@@ -98,7 +98,8 @@ class RFSweep:
         print(f"The current frequency is {self.f_RF + existing_sweep}Hz, adding "
             + f"{self.sweep_per_turn}Hz per turn.")
         print(f"This sweep will move the center of the bucket with \u0394\u03B4 = "
-            + f"{delta_shift} per turn. This implies one bucket shift every {bucket_turns} turns.")
+            + f"{delta_shift} per turn.")
+        print(f"This implies one bucket shift every {bucket_turns} turns.")
         if self.tw.qs * bucket_turns < 3:
             print(f"Warning: This is a very fast sweep, moving ~1 bucket in "
                 + f"~{round(self.tw.qs * bucket_turns, 2)} synchrotron oscillations "
@@ -113,12 +114,12 @@ class RFSweep:
         self.line.track(particles=particles, *args, **kwargs)
 
 
-    def _get_base_frequency(self, sweep):
+    def _get_cavity_data(self, sweep):
+        tt = self.line.get_table()
+        tt_c = tt.rows[[nn for nn, ttt in zip(tt.name, tt.element_type)
+                        if 'Cavity' in ttt and 'CrabCavity' not in ttt]]
+        mask = tt_c.parent_name == None  # Unsliced cavities
         if self.cavities is None:
-            tt = self.line.get_table()
-            tt_c = tt.rows[[nn for nn, ttt in zip(tt.name, tt.element_type)
-                            if 'Cavity' in ttt and 'CrabCavity' not in ttt]]
-            mask = tt_c.parent_name == None  # Unsliced cavities
             self.cavities = np.unique(list(tt_c.name[mask]) + list(tt_c.parent_name[~mask]))
         else:
             if isinstance(self.cavities, str):
@@ -131,6 +132,17 @@ class RFSweep:
         freq = np.array([self.env[cav].frequency for cav in self.cavities])
         volt = np.array([self.env[cav].voltage for cav in self.cavities])
         lag  = np.array([self.env[cav].lag for cav in self.cavities])
+        s_pos = []
+        name_first_in_line = []
+        for cav in self.cavities:
+            if cav in tt_c.name:
+                s_pos.append(tt_c.rows[cav].s_start[0])
+                name_first_in_line.append(cav)
+            elif cav in tt_c.parent_name:
+                s_pos.append(tt_c.rows[tt_c.parent_name == cav].s_start.min())
+                name_first_in_line.append(tt_c.rows[tt_c.parent_name == cav].name[0])
+            else:
+                raise ValueError(f"Cavity `{cav}` not found in the line!")
         idx  = np.argsort(freq)
         boundaries = np.where(~np.isclose(freq[idx][1:], freq[idx][:-1],
                                           rtol=1e-8, atol=1e-12)
@@ -141,7 +153,9 @@ class RFSweep:
                 'names': self.cavities[gidx],
                 'freq': np.mean(freq[gidx]),
                 'voltage': volt[gidx].sum(),
+                's_pos': np.array(s_pos)[gidx],
                 'lag': lag[gidx],
+                'name_first_in_line': np.array(name_first_in_line)[gidx],
             })
         self.cavities = sorted(groups, key=lambda g: (g['voltage'], g['freq']), reverse=True)
         if np.isclose(self.cavities[0]['voltage'], 0):
@@ -154,14 +168,15 @@ class RFSweep:
             print("Found multiple cavities with different frequencies:")
             for g in self.cavities:
                 print(f"{g['freq']}Hz  at {g['voltage']}V: {g['names']}")
-            print(r"The sweep ($\Delta f$ = " + f"{sweep}Hz) will be performed "
-                + f"with respect to the highest voltage cavity at {self.f_RF}Hz"
-                + f". The other cavities will be shifted accordingly.")
+            print(r"The sweep ($\Delta f$ = " + f"{sweep}Hz per turn) will be "
+                + f"performed with respect to the highest voltage cavity at "
+                + f"{self.f_RF}Hz. The other cavities will be shifted "
+                + f"accordingly.")
 
 
     def _install_zeta_shift(self):
         if 'rf_sweep' not in self.env.elements:
-            idx  = np.argsort([self.line.get_s_position(cav) for cav in self.cavities[0]['names']])
-            first_cavity = self.cavities[0]['names'][idx[0]]
+            idx = np.argsort(self.cavities[0]['s_pos'])
+            first_cavity = self.cavities[0]['name_first_in_line'][idx[0]]
             self.env.elements['rf_sweep'] = xt.ZetaShift(dzeta=0)
             self.line.insert('rf_sweep', at=f'{first_cavity}@start')

--- a/xcoll/rf_sweep.py
+++ b/xcoll/rf_sweep.py
@@ -1,197 +1,167 @@
 # copyright ############################### #
 # This file is part of the Xcoll package.   #
-# Copyright (c) CERN, 2024.                 #
+# Copyright (c) CERN, 2025.                 #
 # ######################################### #
 
 import numpy as np
 import scipy.constants as sc
-from time import perf_counter
 
 import xtrack as xt
-from xtrack.progress_indicator import progress
+
+
+def prepare_rf_sweep(line, cavities=None, sweep=None, sweep_per_turn=None, num_turns=None):
+    rf_sweep = RFSweep(line=line, cavities=cavities)
+    rf_sweep.prepare(sweep=sweep, sweep_per_turn=sweep_per_turn, num_turns=num_turns)
+
 
 class RFSweep:
-
-    def __init__(self, line):
+    def __init__(self, line, cavities=None):
         self.line = line
-        self._get_base_frequency()
-        self._install_zeta_shift()
-        self.reset()
-
-    def _get_base_frequency(self):
-        self.cavities = self.line.get_elements_of_type(xt.Cavity)[1]
-        freq = np.unique([round(self.line[cav].frequency, 9) for cav in self.cavities])
-        if len(freq) > 1:
-            raise NotImplementedError(f"Cannot sweep multiple cavities with different frequencies!")
-        elif abs(freq[0]) < 1e-9 :
-            raise ValueError(f"Cavity frequency not set!")
-        self.f_RF = freq[0]
-        phi = np.unique(np.array([self.line[cav].lag for cav in self.cavities])*np.pi/180.)
-        if len(phi) > 1:
-            raise NotImplementedError(f"Cannot sweep multiple cavities with different phases!")
-        self.phi = phi[0]
-        self.V = np.array([self.line[cav].voltage for cav in self.cavities]).sum()
-        self.L = self.line.get_length()
-
-    def _install_zeta_shift(self):
-        if 'rf_sweep' in self.line.element_names:
-            print(f"Found existing RF sweep in line.")
-        else:
-            s_cav = min([self.line.get_s_position(cav) for cav in self.cavities])
-            if self.line.tracker is not None:
-                self.line.unfreeze()
-                line_was_built = True
-            else:
-                line_was_built = False
-            self.line.insert_element(element=xt.ZetaShift(dzeta=0), name='rf_sweep', at_s=s_cav)
-            if line_was_built:
-                self.line.build_tracker()
+        if line._var_management is None:
+            raise ValueError("Line must have a `var_management` to use RFSweep!" \
+                           + "Do not use `optimize_for_tracking` as it will "
+                           + "disable expressions, which are needed for RFSweep.")
+        self.env = line.env
+        self.cavities = cavities
+        self.env['rf_sweep_df'] = 0
 
     @property
     def current_sweep_value(self):
-        dzeta = self.line['rf_sweep'].dzeta
-        return round(self.f_RF * dzeta/(self.L-dzeta), 6)
+        return self.env['rf_sweep_df']
 
-
-    def info(self, sweep=0, num_turns=0):
-        if abs(sweep) > 1e-9:
-            existing_sweep = self.current_sweep_value
-
-            beta0 = self.line.particle_ref.beta0[0]
-            E = self.line.particle_ref.energy0[0]
-            q = self.line.particle_ref.q0
-            h = self.f_RF * self.L / beta0 / sc.c
-            tw = self.line.twiss()
-            eta = tw.slip_factor
-
-            bucket_height = np.sqrt(abs(q*self.V*beta0**2 / (np.pi*h*eta*E) * (
-                                2*np.cos(self.phi) + (2*self.phi-np.pi)*np.sin(self.phi)
-                            )))
-            delta_shift = -sweep / self.f_RF / eta
-            bucket_shift = delta_shift / bucket_height / 2
-            if num_turns > 0:
-                rf_shift_per_turn = sweep / num_turns
-                print(f"The current frequency is {self.f_RF + existing_sweep}Hz, adding {rf_shift_per_turn}Hz "
-                    + f"per turn until {self.f_RF + existing_sweep + sweep} (for {num_turns} turns).")
-            print(f"This sweep will move the center of the bucket with \u0394\u03B4 = "
-                + f"{delta_shift} ({bucket_shift} buckets).")
-            if num_turns > 0 and num_turns < 3*bucket_shift/tw.qs:
-                print(f"Warning: This is a very fast sweep, moving ~{round(bucket_shift, 2)} buckets in "
-                    + f"~{round(num_turns*tw.qs, 2)} synchrotron oscillations (on average). If the "
-                    + f"bucket moves faster than a particle can follow, that particle will move out of "
-                    + f"the bucket and remain uncaptured.")
-
-
-    def track(self, sweep=0, particles=None, num_turns=0, verbose=True, *args, **kwargs):
-
-        # Was there a previous sweep?
-        # If yes, we do not overwrite it but continue from there
-        existing_sweep = self.current_sweep_value
-
-        # Just set the new RF frequency, no tracking
-        if num_turns == 0:
-            sweep += existing_sweep
-            if verbose:
-                print(f"The current frequency is {self.f_RF + existing_sweep}Hz, moving to {self.f_RF + sweep}Hz."
-                     + "No tracking performed.")
-            self.line['rf_sweep'].dzeta = self.L * sweep / (self.f_RF + sweep)
-
-        # Sweep and track
+    def prepare(self, sweep=None, sweep_per_turn=None, num_turns=None):
+        if sweep_per_turn is not None:
+            if np.isclose(sweep_per_turn, 0):
+                raise ValueError("Variable `sweep_per_turn` must be non-zero!")
+            if sweep is not None:
+                raise ValueError("Provide either `sweep` or `sweep_per_turn`, not both.")
+            if num_turns is not None:
+                raise ValueError("Variable `num_turns` cannot be set when using `sweep_per_turn`.")
+            self.sweep_per_turn = sweep_per_turn
+        elif sweep is not None:
+            if np.isclose(sweep, 0):
+                raise ValueError("Variable `sweep` must be non-zero!")
+            if num_turns is None:
+                num_turns = int(abs(sweep))
+            if num_turns <= 0:
+                raise ValueError("When using `sweep`, `num_turns` must be a positive integer.")
+            self.sweep_per_turn = sweep / num_turns
         else:
-            if self.line.tracker is None:
-                raise ValueError("Need to build tracker first!")
-            if particles is None:
-                raise ValueError("Need particles to track!")
-            time = kwargs.pop('time', False)
-            with_progress = kwargs.pop('with_progress', False)
-            rf_shift_per_turn = sweep / num_turns
-
-            # This is taken from xtrack.tracker.Tracker._track
-            if time:
-                t0 = perf_counter()
-            if with_progress:
-                if self.line.tracker.enable_pipeline_hold:
-                    raise ValueError("Progress indicator is not supported with pipeline hold")
-                if num_turns < 2:
-                    raise ValueError('Tracking with progress indicator is only '
-                                    'possible over more than one turn.')
-                if with_progress is True:
-                    batch_size = scaling = 100
+            raise ValueError("Either `sweep` or `sweep_per_turn` must be provided.")
+        self._get_base_frequency(sweep)
+        self._install_zeta_shift()
+        self.reset() # Initialize rf_sweep_df
+        self.env['rf_sweep'].dzeta = f"{self.L} * rf_sweep_df / ({self.f_RF} + rf_sweep_df)"
+        for cavs in self.cavities:
+            for cav in cavs['names']:
+                scale_factor = int(np.round(cavs['freq'] / self.f_RF))
+                if scale_factor == 1:
+                    self.env.ref[cav].frequency += self.env.ref["rf_sweep_df"]
                 else:
-                    batch_size = int(with_progress)
-                    scaling = with_progress if batch_size > 1 else None
-                if kwargs.get('turn_by_turn_monitor') is True:
-                    ele_start = kwargs.get('ele_start') or 0
-                    ele_stop = kwargs.get('ele_stop')
-                    if ele_stop is None:
-                        ele_stop = len(self.line)
-                    if ele_start >= ele_stop:
-                        # we need an additional turn and space in the monitor for
-                        # the incomplete turn
-                        num_turns += 1
-                    _, monitor, _, _ = self.line.tracker._get_monitor(particles, True, num_turns)
-                    kwargs['turn_by_turn_monitor'] = monitor
-
-                for ii in progress(
-                        range(0, num_turns, batch_size),
-                        desc='Tracking',
-                        unit_scale=scaling,
-                ):
-                    one_turn_kwargs = kwargs.copy()
-                    is_first_batch = ii == 0
-                    is_last_batch = ii + batch_size >= num_turns
-
-                    if is_first_batch and is_last_batch:
-                        # This is the only batch, we track as normal
-                        pass
-                    elif is_first_batch:
-                        # Not the last batch, so track until the last element
-                        one_turn_kwargs['ele_stop'] = None
-                        one_turn_kwargs['num_turns'] = batch_size
-                    elif is_last_batch:
-                        # Not the first batch, so track from the first element
-                        one_turn_kwargs['ele_start'] = None
-                        remaining_turns = num_turns % batch_size
-                        if remaining_turns == 0:
-                            remaining_turns = batch_size
-                        one_turn_kwargs['num_turns'] = remaining_turns
-                        one_turn_kwargs['_reset_log'] = False
-                    elif not is_first_batch and not is_last_batch:
-                        # A 'middle batch', track from first to last element
-                        one_turn_kwargs['num_turns'] = batch_size
-                        one_turn_kwargs['ele_start'] = None
-                        one_turn_kwargs['ele_stop'] = None
-                        one_turn_kwargs['_reset_log'] = False
-                    self._tracking_func(particles, rf_shift_per_turn, **one_turn_kwargs)
-                    if not np.any(particles.state == 1):
-                        break
-
-            else:
-                self._tracking_func(particles, rf_shift_per_turn, num_turns=num_turns, *args, **kwargs)
-
-            if not np.any(particles.state == 1):
-                print(f"All particles lost at turn {particles.at_turn.max()}, stopped sweep at "
-                    + f"{self.current_sweep_value}Hz.")
-
-            if time:
-                t1 = perf_counter()
-                self.line.tracker._context.synchronize()
-                self.line.tracker.time_last_track = t1 - t0
-            else:
-                self.line.tracker.time_last_track = None
+                    self.env.ref[cav].frequency += {scale_factor} * self.env.ref["rf_sweep_df"]
+        self.line.enable_time_dependent_vars = True
+        print("Enabled time-dependent variables in the line.")
 
 
     def reset(self):
-        self.line['rf_sweep'].dzeta = 0
+        if self.sweep_per_turn is None:
+            raise ValueError("RFSweep not prepared. Call `prepare` first.")
+        self.tw = self.line.twiss()
+        t_turn = self.tw.T_rev0
+        current_time = self.env['t_turn_s']
+        if current_time == 0:
+            self.env['rf_sweep_df'] = f"t_turn_s / {t_turn} * {self.sweep_per_turn}"
+        else:
+            self.env['rf_sweep_df'] = f"(t_turn_s - {current_time}) / {t_turn} * {self.sweep_per_turn}"
 
 
-    def _tracking_func(self, particles, rf_shift_per_turn, num_turns=1, *args, **kwargs):
+    def info(self, sweep=None, num_turns=None):
+        if sweep is not None:
+            raise DeprecationWarning("The `sweep` argument is deprecated.")
+        if num_turns is not None:
+            raise DeprecationWarning("The `num_turns` argument is deprecated.")
+        if self.sweep_per_turn is None:
+            raise ValueError("RFSweep not prepared. Call `prepare` first.")
         existing_sweep = self.current_sweep_value
-        for i in range(num_turns):
-            sweep = existing_sweep + i*rf_shift_per_turn
-            self.line['rf_sweep'].dzeta = self.L * sweep / (self.f_RF + sweep)
-#             for cav in cavities:
-#                 self.line[cav].frequency = freq + sweep
-            self.line.track(particles, num_turns=1, *args, **kwargs)
-            if not np.any(particles.state == 1):
-                break
+
+        beta0 = self.line.particle_ref.beta0[0]
+        E = self.line.particle_ref.energy0[0]
+        q = self.line.particle_ref.q0
+        h = self.f_RF * self.L / beta0 / sc.c
+        eta = self.tw.slip_factor
+
+        bucket_height = np.sqrt(abs(q*self.V*beta0**2 / (np.pi*h*eta*E) * (
+                            2*np.cos(self.phi) + (2*self.phi-np.pi)*np.sin(self.phi)
+                        )))
+        delta_shift = -self.sweep_per_turn / self.f_RF / eta
+        bucket_turns = bucket_height * 2 / abs(delta_shift)
+        print(f"The current frequency is {self.f_RF + existing_sweep}Hz, adding "
+            + f"{self.sweep_per_turn}Hz per turn.")
+        print(f"This sweep will move the center of the bucket with \u0394\u03B4 = "
+            + f"{delta_shift} per turn. This implies one bucket shift every {bucket_turns} turns.")
+        if self.tw.qs * bucket_turns < 3:
+            print(f"Warning: This is a very fast sweep, moving ~1 bucket in "
+                + f"~{round(self.tw.qs * bucket_turns, 2)} synchrotron oscillations "
+                + f"(on average). If the bucket moves faster than a particle "
+                + f"can follow, that particle will move out of the bucket and "
+                + f"remain uncaptured.")
+
+
+    # For backward compatibility
+    def track(self, sweep=0, particles=None, num_turns=0, verbose=True, *args, **kwargs):
+        self.prepare(sweep, num_turns)
+        self.line.track(particles=particles, *args, **kwargs)
+
+
+    def _get_base_frequency(self, sweep):
+        if self.cavities is None:
+            tt = self.line.get_table()
+            tt_c = tt.rows[[nn for nn, ttt in zip(tt.name, tt.element_type)
+                            if 'Cavity' in ttt and 'CrabCavity' not in ttt]]
+            mask = tt_c.parent_name == None  # Unsliced cavities
+            self.cavities = np.unique(list(tt_c.name[mask]) + list(tt_c.parent_name[~mask]))
+        else:
+            if isinstance(self.cavities, str):
+                self.cavities = [self.cavities]
+            for cav in self.cavities:
+                if cav not in self.env.elements:
+                    raise ValueError(f"Cavity `{cav}` not found in environment!")
+        if len(self.cavities) == 0:
+            raise ValueError("No cavities found in the line!")
+        freq = np.array([self.env[cav].frequency for cav in self.cavities])
+        volt = np.array([self.env[cav].voltage for cav in self.cavities])
+        lag  = np.array([self.env[cav].lag for cav in self.cavities])
+        idx  = np.argsort(freq)
+        boundaries = np.where(~np.isclose(freq[idx][1:], freq[idx][:-1],
+                                          rtol=1e-8, atol=1e-12)
+                              )[0] + 1
+        groups = []
+        for gidx in np.split(idx, boundaries):
+            groups.append({
+                'names': self.cavities[gidx],
+                'freq': np.mean(freq[gidx]),
+                'voltage': volt[gidx].sum(),
+                'lag': lag[gidx],
+            })
+        self.cavities = sorted(groups, key=lambda g: (g['voltage'], g['freq']), reverse=True)
+        if np.isclose(self.cavities[0]['voltage'], 0):
+            raise ValueError("No active cavity found!")
+        self.f_RF = self.cavities[0]['freq']
+        self.phi = np.deg2rad(self.cavities[0]['lag'].mean())
+        self.V = self.cavities[0]['voltage']
+        self.L = self.line.get_length()
+        if len(self.cavities) > 1:
+            print("Found multiple cavities with different frequencies:")
+            for g in self.cavities:
+                print(f"{g['freq']}Hz  at {g['voltage']}V: {g['names']}")
+            print(r"The sweep ($\Delta f$ = " + f"{sweep}Hz) will be performed "
+                + f"with respect to the highest voltage cavity at {self.f_RF}Hz"
+                + f". The other cavities will be shifted accordingly.")
+
+
+    def _install_zeta_shift(self):
+        if 'rf_sweep' not in self.env.elements:
+            idx  = np.argsort([self.line.get_s_position(cav) for cav in self.cavities[0]['names']])
+            first_cavity = self.cavities[0]['names'][idx[0]]
+            self.env.elements['rf_sweep'] = xt.ZetaShift(dzeta=0)
+            self.line.insert('rf_sweep', at=f'{first_cavity}@start')


### PR DESCRIPTION
- **Created release branch release/v0.6.3rc0.**
- **Move xcoll elements for prebuild kernels from Xsuite in Xcoll.**
- **Pytest config file (merged from release/v0.7.0).**
- **Accidentally merged wrong version number.**
- **Updated RFSweep to use time-dependent variables as the old implementation had become very slow.**
- **Fixed bug with sliced Cavity.**
- **Small typo with sliced Cavity, and added SPS example machine to get test with sliced Cavity.**
- **Updated version number to v0.6.3.**
