### PR TITLE
Add Geant4CollimatorTip

### DIFF
--- a/xcoll/__init__.py
+++ b/xcoll/__init__.py
@@ -6,7 +6,7 @@
 from .general import _pkg_root, __version__, citation
 
 from .beam_elements import BlackAbsorber, BlackCrystal, TransparentCollimator, TransparentCrystal, \
-                           EverestBlock, EverestCollimator, EverestCrystal, Geant4Collimator, Geant4Crystal, \
+                           EverestBlock, EverestCollimator, EverestCrystal, Geant4Collimator, Geant4CollimatorTip, Geant4Crystal, \
                            BlowUp, EmittanceMonitor, collimator_classes, crystal_classes, element_classes
 from .scattering_routines.everest import materials, Material, CrystalMaterial
 from .scattering_routines.geant4 import Geant4Engine

--- a/xcoll/beam_elements/__init__.py
+++ b/xcoll/beam_elements/__init__.py
@@ -7,7 +7,7 @@ from .base import BaseBlock, BaseCollimator, BaseCrystal
 from .absorber import BlackAbsorber, BlackCrystal
 from .transparent import TransparentCollimator, TransparentCrystal
 from .everest import EverestBlock, EverestCollimator, EverestCrystal
-from .geant4 import Geant4Collimator, Geant4Crystal
+from .geant4 import Geant4Collimator, Geant4CollimatorTip, Geant4Crystal
 from .blowup import BlowUp
 from .monitor import EmittanceMonitor
 

--- a/xcoll/beam_elements/elements_src/geant4_collimator_tip.h
+++ b/xcoll/beam_elements/elements_src/geant4_collimator_tip.h
@@ -1,0 +1,123 @@
+// copyright ############################### #
+// This file is part of the Xcoll Package.   #
+// Copyright (c) CERN, 2024.                 #
+// ######################################### #
+
+#ifndef XCOLL_GEANT4_TIP_H
+#define XCOLL_GEANT4_TIP_H
+
+
+/*gpufun*/
+int8_t Geant4CollimatorTipData_get_record_impacts(Geant4CollimatorTipData el){
+    return Geant4CollimatorTipData_get__record_interactions(el) % 2;
+}
+
+/*gpufun*/
+int8_t Geant4CollimatorTipData_get_record_exits(Geant4CollimatorTipData el){
+    return (Geant4CollimatorTipData_get__record_interactions(el) >> 1) % 2;
+}
+
+/*gpufun*/
+int8_t Geant4CollimatorTipData_get_record_scatterings(Geant4CollimatorTipData el){
+    return (Geant4CollimatorTipData_get__record_interactions(el) >> 2) % 2;
+}
+
+
+/*gpufun*/
+CollimatorGeometry Geant4CollimatorTip_init_geometry(Geant4CollimatorTipData el, LocalParticle* part0, int8_t active){
+    CollimatorGeometry cg = (CollimatorGeometry) malloc(sizeof(CollimatorGeometry_));
+    if (active){ // This is needed in order to avoid that the initialisation is called during a twiss!
+        // Jaw corners (with tilts)
+        cg->jaw_LU = Geant4CollimatorTipData_get__jaw_LU(el);
+        cg->jaw_RU = Geant4CollimatorTipData_get__jaw_RU(el);
+        // Get angles of jaws
+        cg->sin_zL = Geant4CollimatorTipData_get__sin_zL(el);
+        cg->cos_zL = Geant4CollimatorTipData_get__cos_zL(el);
+        cg->sin_zR = Geant4CollimatorTipData_get__sin_zR(el);
+        cg->cos_zR = Geant4CollimatorTipData_get__cos_zR(el);
+        cg->sin_zDiff = Geant4CollimatorTipData_get__sin_zDiff(el);
+        cg->cos_zDiff = Geant4CollimatorTipData_get__cos_zDiff(el);
+        cg->jaws_parallel = Geant4CollimatorTipData_get__jaws_parallel(el);
+        // Tilts
+        cg->sin_yL = Geant4CollimatorTipData_get__sin_yL(el);
+        cg->cos_yL = Geant4CollimatorTipData_get__cos_yL(el);
+        cg->sin_yR = Geant4CollimatorTipData_get__sin_yR(el);
+        cg->cos_yR = Geant4CollimatorTipData_get__cos_yR(el);
+        // Length and segments
+        cg->length = Geant4CollimatorTipData_get_length(el);
+        cg->side   = Geant4CollimatorTipData_get__side(el);
+        double s_U, s_D, x_D;
+        if (cg->side != -1){
+            s_U = cg->length/2 * (1-cg->cos_yL);
+            s_D = cg->length/2 * (1+cg->cos_yL);
+            x_D = Geant4CollimatorTipData_get__jaw_LD(el);
+            cg->segments_L = create_jaw(s_U, cg->jaw_LU, s_D, x_D, cg->sin_yL/cg->cos_yL, 1);
+        }
+        if (cg->side != 1){
+            s_U = cg->length/2 * (1-cg->cos_yR);
+            s_D = cg->length/2 * (1+cg->cos_yR);
+            x_D = Geant4CollimatorTipData_get__jaw_RD(el);
+            cg->segments_R = create_jaw(s_U, cg->jaw_RU, s_D, x_D, cg->sin_yR/cg->cos_yR, -1);
+        }
+        // Impact table
+        cg->record = Geant4CollimatorTipData_getp_internal_record(el, part0);
+        cg->record_index = NULL;
+        cg->record_impacts = 0;
+        cg->record_exits = 0;
+        if (cg->record){
+            cg->record_index = InteractionRecordData_getp__index(cg->record);
+            cg->record_impacts = Geant4CollimatorTipData_get_record_impacts(el);
+            cg->record_exits = Geant4CollimatorTipData_get_record_exits(el);
+        }
+    }
+
+    return cg;
+}
+
+/*gpufun*/
+void Geant4CollimatorTip_free(CollimatorGeometry restrict cg, int8_t active){
+    if (active){
+        if (cg->side != -1){
+            destroy_jaw(cg->segments_L);
+        }
+        if (cg->side != 1){
+            destroy_jaw(cg->segments_R);
+        }
+    }
+    free(cg);
+}
+
+
+/*gpufun*/
+void Geant4CollimatorTip_track_local_particle(Geant4CollimatorTipData el, LocalParticle* part0){
+
+    // Collimator active and length
+    int8_t active = Geant4CollimatorTipData_get_active(el);
+    active       *= Geant4CollimatorTipData_get__tracking(el);
+    double const length = Geant4CollimatorTipData_get_length(el);
+
+    // Get geometry
+    CollimatorGeometry cg     = Geant4CollimatorTip_init_geometry(el, part0, active);
+
+    //start_per_particle_block (part0->part)
+        if (!active){
+            // Drift full length
+            Drift_single_particle(part, length);
+
+        } else {
+            // Check collimator initialisation
+            int8_t is_tracking = assert_tracking(part, XC_ERR_INVALID_TRACK);
+
+            if (is_tracking) {
+                LocalParticle_set_s(part, 0);
+
+                // Check if hit on jaws
+                int8_t is_hit = hit_jaws_check_and_transform(part, cg);
+                (void) is_hit;
+            }
+        }
+    //end_per_particle_block
+    Geant4CollimatorTip_free(cg, active);
+}
+
+#endif /* XCOLL_GEANT4_TIP_H */

--- a/xcoll/beam_elements/geant4.py
+++ b/xcoll/beam_elements/geant4.py
@@ -20,7 +20,7 @@ from ..scattering_routines.everest.materials import _SixTrack_to_xcoll, SixTrack
 
 
 class Geant4Collimator(BaseCollimator):
-    
+
     _xofields = BaseCollimator._xofields | {
         'geant4_id': xo.Int16,
         '_material': xo.String,

--- a/xcoll/colldb.py
+++ b/xcoll/colldb.py
@@ -13,13 +13,14 @@ from pathlib import Path
 import xtrack as xt
 
 from .beam_elements import BlackAbsorber, BlackCrystal, EverestCollimator, EverestCrystal, \
-                           Geant4Collimator, BaseCollimator, BaseCrystal, collimator_classes
+                           Geant4Collimator, Geant4CollimatorTip, BaseCollimator, BaseCrystal, collimator_classes
 from .scattering_routines.everest.materials import SixTrack_to_xcoll
 
 
 def _initialise_None(dct):
     fields = {'gap': None, 'angle': 0, 'offset': 0, 'parking': 1, 'jaw': None, 'family': None}
     fields.update({'overwritten_keys': [], 'side': 'both', 'material': None, 'stage': None})
+    fields.update({'tip_material': None, 'tip_thickness': None})
     fields.update({'length': 0, 'collimator_type': None, 'active': True, 'crystal': None, 'tilt': 0})
     fields.update({'bending_radius': None, 'bending_angle': None, 'width': 0, 'height': 0, 'miscut': 0})
     for f, val in fields.items():
@@ -593,8 +594,12 @@ class CollimatorDatabase:
         for name in names:
             if self[name]['bending_radius'] is not None:
                 raise ValueError("Geant4Crystal not yet supported!")
-            self._create_collimator(Geant4Collimator, line, name, verbose=verbose,
-                                    material=self[name]['material'], geant4_id=name)
+            if self[name]['tip_material'] is None:
+                self._create_collimator(Geant4Collimator, line, name, verbose=verbose,
+                                        material=self[name]['material'], geant4_id=name)
+            else:
+                self._create_collimator(Geant4CollimatorTip, line, name, verbose=verbose,
+                                        material=self[name]['material'], geant4_id=name)
         elements = [self._elements[name] for name in names]
         line.collimators.install(names, elements, need_apertures=need_apertures)
 

--- a/xcoll/colldb.py
+++ b/xcoll/colldb.py
@@ -594,7 +594,7 @@ class CollimatorDatabase:
             if self[name]['bending_radius'] is not None:
                 raise ValueError("Geant4Crystal not yet supported!")
             self._create_collimator(Geant4Collimator, line, name, verbose=verbose,
-                                    material=self[name]['material'])
+                                    material=self[name]['material'], geant4_id=name)
         elements = [self._elements[name] for name in names]
         line.collimators.install(names, elements, need_apertures=need_apertures)
 

--- a/xcoll/lib/collimasim/src/collimasim/BDSXtrackInterface.cpp
+++ b/xcoll/lib/collimasim/src/collimasim/BDSXtrackInterface.cpp
@@ -232,6 +232,8 @@ XtrackInterface::~XtrackInterface()
 
 void XtrackInterface::addCollimator(const std::string&   name,
                                     const std::string&   material,
+                                    const std::string&   tipMaterial,
+                                    double tipThickness,
                                     double lengthIn,
                                     double apertureLeftIn,
                                     double apertureRightIn,
@@ -247,20 +249,42 @@ void XtrackInterface::addCollimator(const std::string&   name,
         bool buildLeft  = side == 0 || side == 1;
         bool buildRight = side == 0 || side == 2;
 
-        bds->AddLinkCollimatorJaw(name,
-                                  material,
-                                  lengthIn * CLHEP::m,
-                                  apertureLeftIn * CLHEP::m,
-                                  apertureRightIn * CLHEP::m,
-                                  rotationIn * CLHEP::rad,
-                                  xOffsetIn * CLHEP::m,
-                                  yOffsetIn * CLHEP::m,
-                                  jawTiltLeft * CLHEP::rad,
-                                  jawTiltRight * CLHEP::rad,
-                                  buildLeft,
-                                  buildRight,
-                                  isACrystal,
-                                  0);
+        bool isTipped = !tipMaterial.empty() && tipThickness > 0.0;
+
+        if (isTipped):
+        {
+            bds->AddLinkCollimatorTipJaw(name,
+                                         material,
+                                         tipMaterial,
+                                         tipThickness * CLHEP::m,
+                                         lengthIn * CLHEP::m,
+                                         apertureLeftIn * CLHEP::m,
+                                         apertureRightIn * CLHEP::m,
+                                         rotationIn * CLHEP::rad,
+                                         xOffsetIn * CLHEP::m,
+                                         yOffsetIn * CLHEP::m,
+                                         jawTiltLeft * CLHEP::rad,
+                                         jawTiltRight * CLHEP::rad,
+                                         buildLeft,
+                                         buildRight);
+        }
+        else
+        {
+            bds->AddLinkCollimatorJaw(name,
+                                      material,
+                                      lengthIn * CLHEP::m,
+                                      apertureLeftIn * CLHEP::m,
+                                      apertureRightIn * CLHEP::m,
+                                      rotationIn * CLHEP::rad,
+                                      xOffsetIn * CLHEP::m,
+                                      yOffsetIn * CLHEP::m,
+                                      jawTiltLeft * CLHEP::rad,
+                                      jawTiltRight * CLHEP::rad,
+                                      buildLeft,
+                                      buildRight,
+                                      isACrystal,
+                                      0);
+        }
     }
 
 

--- a/xcoll/lib/collimasim/src/collimasim/BDSXtrackInterface.cpp
+++ b/xcoll/lib/collimasim/src/collimasim/BDSXtrackInterface.cpp
@@ -251,7 +251,7 @@ void XtrackInterface::addCollimator(const std::string&   name,
 
         bool isTipped = !tipMaterial.empty() && tipThickness > 0.0;
 
-        if (isTipped):
+        if (isTipped)
         {
             bds->AddLinkCollimatorTipJaw(name,
                                          material,

--- a/xcoll/lib/collimasim/src/collimasim/BDSXtrackInterface.hh
+++ b/xcoll/lib/collimasim/src/collimasim/BDSXtrackInterface.hh
@@ -69,6 +69,8 @@ public:
 
     void addCollimator(const  std::string&   name,
                        const  std::string&   material,
+                       const  std::string&   tipMaterial,
+                       double tipThickness,
                        double lengthIn,
                        double apertureLeftIn,
                        double apertureRightIn,

--- a/xcoll/lib/collimasim/src/collimasim/bindings.cpp
+++ b/xcoll/lib/collimasim/src/collimasim/bindings.cpp
@@ -18,7 +18,7 @@ PYBIND11_MODULE(g4interface, m) {
                  "relativeEnergyCut"_a, "seed"_a, "referenceIonCharge"_a=0,"batchMode"_a=true,
                  py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>())
             .def("addCollimator", &XtrackInterface::addCollimator,
-                 "name"_a, "material"_a, "length"_a, "apertureLeft"_a, "apertureRight"_a, "rotation"_a,
+                 "name"_a, "material"_a, "tipMaterial"_a, "tipThickness"_a, "length"_a, "apertureLeft"_a, "apertureRight"_a, "rotation"_a,
                  "xOffset"_a, "yOffset"_a, "jawTiltLeft"_a, "jawTiltRight"_a, "side"_a, "isACrystal"_a,
                  py::call_guard<py::scoped_ostream_redirect, py::scoped_estream_redirect>())
             /// The cast here to disambiguate overloaded methods. The other versions of

--- a/xcoll/lossmap.py
+++ b/xcoll/lossmap.py
@@ -274,7 +274,7 @@ class LossMap:
                         part.state[idx] = LOST_ON_FLUKA_CRYSTAL
                     elif what_type == 'Geant4Block':
                         part.state[idx] = LOST_ON_GEANT4_BLOCK
-                    elif what_type == 'Geant4Collimator':
+                    elif what_type == 'Geant4Collimator' or what_type == 'Geant4CollimatorTip':
                         part.state[idx] = LOST_ON_GEANT4_COLL
                     elif what_type == 'Geant4Crystal':
                         part.state[idx] = LOST_ON_GEANT4_CRYSTAL

--- a/xcoll/scattering_routines/geant4/engine.py
+++ b/xcoll/scattering_routines/geant4/engine.py
@@ -40,7 +40,7 @@ class Geant4Engine(BaseEngine):
     def __init__(self, **kwargs):
         # Set element classes dynamically
         from ...beam_elements import Geant4Collimator, Geant4CollimatorTip, Geant4Crystal
-        self.__class__._element_classes = (Geant4Collimator, Geant4CollimatorTip, Geant4Crystal)
+        self.__class__._element_classes = (Geant4Collimator, Geant4Crystal)
         # Initialise geant4-only defaults
         self._g4link = None
         self._server = None # remove after geant4 bugfix


### PR DESCRIPTION
## Description
This pull request introduces a new collimator type Geant4CollimatorTip. This is a jaw collimator featuring a bulk material and a tip made of a different material.

The addition of this new collimator type is necessary to accurately study collimation in the SuperKEKB collider, as the existing Geant4Collimator does not realistically represent SuperKEKB collimators, which have of a copper (Cu) bulk with a small tip made of a denser material (typically tungsten (W) or tantalum (Ta)). This distinction is relevant for precise beam loss simulations.

For further details, see:
[G. Broggi, SuperKEKB beam loss simulations in Xsuite](https://indico.belle2.org/event/14239/contributions/87590/attachments/32434/47916/SuperKEKB_beam_loss_simulations_Xsuite_GB.pdf) (slide 25), presented at the BELLE-II beam background meeting, 29/01/2025.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [ ] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
