### PR TITLE
Changed API of beam element transformations active

### DIFF
--- a/xcoll/line_tools.py
+++ b/xcoll/line_tools.py
@@ -337,8 +337,7 @@ class XcollCollimatorAPI(XcollLineAccessor):
                 aper_mid = self.get_apertures_at_s(s=(s_start+s_end)/2, table=table, s_tol=s_tol)
                 if aper_mid is None:
                     raise ValueError(f"No aperture found for {name}! Please provide one.")
-                if self.line[aper_mid].allow_rot_and_shift \
-                and xt.base_element._tranformations_active(self.line[aper_mid]):
+                if self.line[aper_mid].transformations_active:
                     print(f"Warning: Using the centre aperture for {name}, but "
                         + f"transformations are present. Proceed with caution.")
                 aper1 = aper_mid


### PR DESCRIPTION
**Don't Merge Yet – only to be released with _Xtrack 0.95.0_**

## Description

As a result of removing "special values" for `_sin_rot_s` to enable/disable transformations (instead we simply store angles, shifts, and zero values mean disabled) the API for transformations was simplified. However, I noticed that Xcoll was using one of the functions I deleted in one place, so I have reintroduced it as a proper method of the `BaseElement`, which requires the following change.

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [x] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
