### PR TITLE
Update monitor to handle zero emittance case

### DIFF
--- a/xcoll/beam_elements/monitor.py
+++ b/xcoll/beam_elements/monitor.py
@@ -390,6 +390,14 @@ class EmittanceMonitor(xt.BeamElement):
                     + f"One of the coordinates might be close to zero or not "
                     + f"varying enough among the different particles. Only "
                     + f"{N[i]} particles were logged at this step.")
+
+                # Check for all zero matrix -> zero emittance
+                if np.all(covariance_S < 1E-16):
+                    gemitt_I.append(0)
+                    gemitt_II.append(0)
+                    gemitt_III.append(0)
+                    continue
+            
             rank = np.linalg.matrix_rank(covariance_S)
             expected_rank = int(self.horizontal) + int(self.vertical) + int(self.longitudinal)
             if rank < expected_rank:


### PR DESCRIPTION
## Description
Add a further check beyond the high condition number
If the condition number is very high, this could indicate the whole matrix is zero
An all zero matrix should imply a zero emittance, but errors would be thrown with the previous implementation

Closes #169 

## Checklist

Mandatory: 

- [ ] I have added tests to cover my changes
- [ ] All the tests are passing, including my new ones
- [x] I described my changes in this PR description

Optional:

- [x] The code I wrote follows good style practices (see [PEP 8](https://peps.python.org/pep-0008/) and [PEP 20](https://peps.python.org/pep-0020/)).
- [ ] I have updated the docs in relation to my changes, if applicable
- [ ] I have tested also GPU contexts
