### PR TITLE
Needed dev to solve prototypes in general and fluka beambeamroutine

### DIFF
--- a/examples/fluka_beambeam_routine.py
+++ b/examples/fluka_beambeam_routine.py
@@ -1,0 +1,159 @@
+import numpy as np
+import sys, os, contextlib
+import time
+import math
+
+from pathlib import Path
+
+import xobjects as xo
+import xtrack as xt
+import xcoll as xc
+import xpart as xp
+
+import argparse
+import pandas as pd
+
+
+path_in = Path("/eos/project-c/collimation-team/machine_configurations/LHC_run3/2025/xsuite")
+path_out = Path.cwd()
+
+beam          = 1
+
+import matplotlib.pyplot as plt
+
+def FlukaBeamBeamSource(line, colldb, int_type, ip, num_particles, pdg_id_b1, p0c_b1, Z_b2, A_b2,
+                        sigma_p_x2 = 0, sigma_p_y2 = 0, sigma_z = 0, sigma_dpp = 0):
+
+    _capacity = num_particles * 100
+    tw = line.twiss()
+    if ip == "ip1":
+        xsx = line["on_x1"]
+        xsv = 0
+        phi_ir = line['phi_ir1']
+    elif ip == "ip2":
+        xsx = line["on_x2h"]
+        phi_ir = line['phi_ir2']
+        xsv = line["on_x2v"]
+    elif ip == "ip5":
+        xsx = line["on_x5"]
+        xsv = 0
+        phi_ir = line['phi_ir5']
+    elif ip == "ip8":
+        xsx = line["on_x8h"]
+        xsv = line["on_x8v"]
+        phi_ir = line['phi_ir8']
+
+    theta2 = (math.sqrt(xsx**2 + xsv**2) * 1e-6)
+
+    # if theta2 is negative, make it positive and change sing to phi_ir
+    if xsx < 0 or xsv < 0:
+        theta2 = -theta2
+        phi_ir = -phi_ir
+
+    geo_emittance_x = tw.beta0*tw.gamma0*colldb.nemitt_x
+    geo_emittance_y = tw.beta0*tw.gamma0*colldb.nemitt_y
+
+    sigma_p_x2 = (geo_emittance_x*(tw.rows[ip].gamx)[0])**0.5
+    sigma_p_y2 = (geo_emittance_y*(tw.rows[ip].gamy)[0])**0.5
+    
+
+
+    bb_int = {
+            'int_type': int_type,
+            'theta2': theta2, # Angle between b2 and -Z
+            'xs': phi_ir,
+            'sigma_p_x2': sigma_p_x2,
+            'sigma_p_y2': sigma_p_y2,
+            'Z': Z_b2,
+            'A': A_b2,
+            'betx': (tw.rows[ip].betx)[0],
+            'bety': (tw.rows[ip].bety)[0],
+            'dx': (tw.rows[ip].dx)[0],
+            'dy': (tw.rows[ip].dy)[0],
+            'alfx': (tw.rows[ip].alfx)[0],
+            'alfy': (tw.rows[ip].alfy)[0],
+            'dpx': (tw.rows[ip].dpx)[0],
+            'dpy': (tw.rows[ip].dpy)[0],
+            'rms_emx': colldb.nemitt_x, #/(tw.beta0* tw.gamma0),
+            'rms_emy': colldb.nemitt_y, #/(tw.beta0* tw.gamma0)
+            'offset': [tw.rows[ip].x[0], tw.rows[ip].px[0], tw.rows[ip].y[0], tw.rows[ip].py[0]],
+            'sigma_z': sigma_z * 1e2,
+            'sigma_dpp': sigma_dpp
+            }
+
+    coll_dummy = xc.FlukaCollimator(assembly="lhc_ippipe", length=0.6, jaw=0.001)
+
+    xc.fluka.engine.particle_ref = xt.Particles.reference_from_pdg_id(pdg_id=pdg_id_b1, p0c=p0c_b1)
+    xc.fluka.engine.capacity = _capacity
+    xc.fluka.engine.relative_capacity = 20 #100
+    # xc.fluka.engine.seed = 5656565
+    xc.fluka.engine.start(elements=coll_dummy, clean=False , verbose=True, include_showers=False, return_ions=True, bb_int=bb_int, touches=False)
+
+
+    line.build_tracker()
+
+    nemitt_x = colldb.nemitt_x
+    nemitt_y = colldb.nemitt_y
+    bunch_intensity = 1.8E11
+    particles = xp.generate_matched_gaussian_bunch(
+        num_particles=num_particles, total_intensity_particles=bunch_intensity,
+        nemitt_x=nemitt_x, nemitt_y=nemitt_y, sigma_z=sigma_z,
+        line=line, particle_ref=xc.fluka.engine.particle_ref)
+    part_init = line.build_particles(x=particles.x, y=particles.y,
+                            px=particles.px,
+                            py=particles.py,
+                            zeta=particles.zeta,
+                            delta=particles.delta,
+                            nemitt_x=colldb.nemitt_x,
+                            nemitt_y=colldb.nemitt_y,
+                            at_element=ip,
+                            match_at_s=line.get_s_position(ip),
+                            particle_ref=xc.fluka.engine.particle_ref,
+                            _capacity=xc.fluka.engine.capacity,
+    mode="normalized_transverse")
+    part = part_init.copy()
+
+    print(f"Tracking {num_particles} particles (FLUKA)...     ", end='')
+    start = time.time()
+    coll_dummy.track(part)
+    print(f"Done in {round(time.time()-start, 3)}s.")
+    xc.fluka.engine.stop(clean=False)
+
+    line.discard_tracker()
+
+    return part
+
+
+start_time = time.time()
+
+# Path to inputs
+path_out = Path('./')
+path_out.mkdir(exist_ok=True)
+
+num_particles = int(100) #0
+
+line = xt.load(path_in / f'levelling.23_b{beam}.json')
+
+colldb = xc.CollimatorDatabase.from_yaml(path_in / ".." / "colldbs" / f'levelling.23.yaml', beam=beam)
+
+part = FlukaBeamBeamSource(
+    line=line,
+    colldb=colldb,
+    int_type=1.0, # 1.0 inelastic, 10.0 elastic, 100.0 Emd
+    ip="ip1",
+    num_particles=num_particles,
+    pdg_id_b1='proton',
+    p0c_b1=6.8e12,
+    Z_b2=1,
+    A_b2=1,
+    sigma_z = 8e-2,
+    sigma_dpp = 1.1e-4
+)
+import pdb; pdb.set_trace()
+
+import pickle
+part_pkl_init = path_out / f'part_init.pkl'
+part_dpp_cut_init = part.filter(part.pdg_id != -999999999)
+with open(part_pkl_init, 'wb') as fid_out:
+    pickle.dump(part_dpp_cut_init.to_dict(), fid_out)
+

--- a/examples/fluka_beambeam_routine.py
+++ b/examples/fluka_beambeam_routine.py
@@ -17,14 +17,16 @@ import pandas as pd
 path_in = Path("/eos/project-c/collimation-team/machine_configurations/LHC_run3/2025/xsuite")
 path_out = Path.cwd()
 
-beam          = 1
+beam = 1
+ions = True
+dump = False
 
 import matplotlib.pyplot as plt
 
 def FlukaBeamBeamSource(line, colldb, int_type, ip, num_particles, pdg_id_b1, p0c_b1, Z_b2, A_b2,
                         sigma_p_x2 = 0, sigma_p_y2 = 0, sigma_z = 0, sigma_dpp = 0):
 
-    _capacity = num_particles * 100
+    _capacity = num_particles * 10000
     tw = line.twiss()
     if ip == "ip1":
         xsx = line["on_x1"]
@@ -85,7 +87,8 @@ def FlukaBeamBeamSource(line, colldb, int_type, ip, num_particles, pdg_id_b1, p0
 
     xc.fluka.engine.particle_ref = xt.Particles.reference_from_pdg_id(pdg_id=pdg_id_b1, p0c=p0c_b1)
     xc.fluka.engine.capacity = _capacity
-    xc.fluka.engine.relative_capacity = 20 #100
+    xc.fluka.engine.relative_capacity = 200 if ions else 20
+
     # xc.fluka.engine.seed = 5656565
     xc.fluka.engine.start(elements=coll_dummy, clean=False , verbose=True, include_showers=False, return_ions=True, bb_int=bb_int, touches=False)
 
@@ -127,33 +130,67 @@ def FlukaBeamBeamSource(line, colldb, int_type, ip, num_particles, pdg_id_b1, p0
 start_time = time.time()
 
 # Path to inputs
-path_out = Path('./')
 path_out.mkdir(exist_ok=True)
 
-num_particles = int(100) #0
+num_particles = int(100)
 
 line = xt.load(path_in / f'levelling.23_b{beam}.json')
 
 colldb = xc.CollimatorDatabase.from_yaml(path_in / ".." / "colldbs" / f'levelling.23.yaml', beam=beam)
 
-part = FlukaBeamBeamSource(
-    line=line,
-    colldb=colldb,
-    int_type=1.0, # 1.0 inelastic, 10.0 elastic, 100.0 Emd
-    ip="ip1",
-    num_particles=num_particles,
-    pdg_id_b1='proton',
-    p0c_b1=6.8e12,
-    Z_b2=1,
-    A_b2=1,
-    sigma_z = 8e-2,
-    sigma_dpp = 1.1e-4
-)
-import pdb; pdb.set_trace()
+if not ions:
+    # p-p example
+    part = FlukaBeamBeamSource(
+        line=line,
+        colldb=colldb,
+        int_type=1.0, # 1.0 inelastic, 10.0 elastic, 100.0 Emd
+        ip="ip1",
+        num_particles=num_particles,
+        pdg_id_b1='proton',
+        p0c_b1=6.8e12,
+        Z_b2=1,
+        A_b2=1,
+        sigma_z = 8e-2,
+        sigma_dpp = 1.1e-4
+    )
 
-import pickle
-part_pkl_init = path_out / f'part_init.pkl'
-part_dpp_cut_init = part.filter(part.pdg_id != -999999999)
-with open(part_pkl_init, 'wb') as fid_out:
-    pickle.dump(part_dpp_cut_init.to_dict(), fid_out)
+if ions:
+    # Pb-Pb example
+    part = FlukaBeamBeamSource(
+        line=line,
+        colldb=colldb,
+        int_type=1.0, # 1.0 inelastic, 10.0 elastic, 100.0 Emd
+        ip="ip1",
+        num_particles=num_particles,
+        pdg_id_b1='Pb208',
+        p0c_b1=6.8e12*82,
+        Z_b2=82,
+        A_b2=208,
+        sigma_z = 8e-2,
+        sigma_dpp = 1.1e-4
+    )
+
+
+part_alive = part.filter(part.state == 1)
+values, counts = np.unique(part_alive.pdg_id, return_counts=True)
+
+# Bar chart with string labels
+labels = [str(v) for v in values]
+
+plt.figure(figsize=(6,4))
+plt.yscale('log')
+plt.bar(labels, counts, color='skyblue', edgecolor='black')
+plt.xlabel('Particles')
+plt.ylabel('Counts')
+plt.tight_layout()
+plt.xticks(rotation=90)
+        
+plt.show()
+
+if dump:
+    import pickle
+    part_pkl_init = path_out / f'part_init.pkl'
+    part_dpp_cut_init = part.filter(part.pdg_id != -999999999)
+    with open(part_pkl_init, 'wb') as fid_out:
+        pickle.dump(part_dpp_cut_init.to_dict(), fid_out)
 

--- a/xcoll/beam_elements/fluka.py
+++ b/xcoll/beam_elements/fluka.py
@@ -208,7 +208,7 @@ class FlukaCollimator(BaseCollimator):
 
     def track(self, part):
         if track_pre(self, part):
-            if self.material != "vacuum":# and False:
+            if self.assembly.name != "IPPIPE":# and False:
                 super().track(part)
             else:
                 part.state[part.state == 1] = HIT_ON_FLUKA_COLL

--- a/xcoll/beam_elements/fluka.py
+++ b/xcoll/beam_elements/fluka.py
@@ -208,7 +208,7 @@ class FlukaCollimator(BaseCollimator):
 
     def track(self, part):
         if track_pre(self, part):
-            if self.material != "vacuum" and False:
+            if self.material != "vacuum":# and False:
                 super().track(part)
             else:
                 part.state[part.state == 1] = HIT_ON_FLUKA_COLL

--- a/xcoll/colldb.py
+++ b/xcoll/colldb.py
@@ -567,7 +567,14 @@ class CollimatorDatabase:
             else:
                 self._create_collimator(FlukaCollimator, line, name, material=mat, verbose=verbose, **extra_kwargs)
         elements = [self._elements[name] for name in names]
-        line.collimators.install(names, elements, need_apertures=need_apertures)
+        at = []
+        for name in names:
+            s_center = getattr(self, 's_center')[name]
+            if s_center is None:
+                at.append(None)
+            else:
+                at.append(s_center - 0.5*getattr(self, 'length')[name])
+        line.collimators.install(names, elements, at=at, apertures=apertures, need_apertures=need_apertures)
 
     def install_geant4_collimators(self, line, *, names=None, families=None, apertures=None,
                                 need_apertures=True, s_tol=1e-6, verbose=False):

--- a/xcoll/scattering_routines/fluka/fedb/metadata/coupling/lhc_IPPIPE.bodies.json
+++ b/xcoll/scattering_routines/fluka/fedb/metadata/coupling/lhc_IPPIPE.bodies.json
@@ -3,6 +3,7 @@
     "name": "IPPIPE",
     "fedb_series": "lhc",
     "fedb_tag": "IPPIPE",
+    "container": "IPPIPEO",
     "side": null,
     "angle": 0,
     "length": null,

--- a/xcoll/scattering_routines/fluka/includes.py
+++ b/xcoll/scattering_routines/fluka/includes.py
@@ -37,7 +37,7 @@ def get_include_files(particle_ref, include_files=[], *, verbose=True, assemblie
         physics_file = _physics_include_file(verbose=verbose, lower_momentum_cut=phys.hadron_lower_momentum_cut,
                                              photon_lower_momentum_cut=phys.photon_lower_momentum_cut,
                                              electron_lower_momentum_cut=phys.electron_lower_momentum_cut,
-                                             include_showers=phys.include_showers)
+                                             include_showers=phys.include_showers, bb_int=bb_int)
         this_include_files.append(physics_file)
     if 'include_custom_scoring.inp' not in [file.name for file in this_include_files]:
         scoring_file = _scoring_include_file(verbose=verbose, return_list=phys,
@@ -196,7 +196,7 @@ SOURCE           0.0       0.0      97.0       1.0      96.0       1.0&&
 
 
 def _physics_include_file(*, verbose, lower_momentum_cut, photon_lower_momentum_cut,
-                          electron_lower_momentum_cut, include_showers):
+                          electron_lower_momentum_cut, include_showers, bb_int=False):
     filename = FsPath("include_settings_physics.inp").resolve()
     emf = "*EMF" if include_showers else "EMF"
     deltaray = "DELTARAY" if not include_showers else "*DELTARAY"
@@ -206,6 +206,7 @@ def _physics_include_file(*, verbose, lower_momentum_cut, photon_lower_momentum_
     electron_lower_energy_cut = sqrt(electron_lower_momentum_cut**2 + 511e3**2)
     electron_lower_energy_cut = format_fluka_float(electron_lower_energy_cut/1.e9)
     lower_momentum_cut /= 1.e9
+    bb = "PHYSICS           -1" if not bb_int else "PHYSICS       8000.0"
     if verbose:
         print(f"Physics include file created with:\n"
              + f"  - Hadron and muon lower momentum cut: {lower_momentum_cut} GeV")
@@ -251,7 +252,8 @@ PHYSICS           3.                                                  EVAPORAT
 PHYSICS        1.D+5     1.D+5     1.D+5     1.D+5     1.D+5     1.D+5PEATHRES
 PHYSICS           2.                                                  EM-DISSO
 * beam-beam collisions
-PHYSICS           -1                                                  LIMITS
+* PHYSICS       8000.0                                                  LIMITS
+{bb}                                                  LIMITS
 * No low-energy neutron transport
 LOW-PWXS          -1
 """

--- a/xcoll/scattering_routines/fluka/prototype.py
+++ b/xcoll/scattering_routines/fluka/prototype.py
@@ -45,7 +45,7 @@ class FlukaPrototype:
             FlukaPrototype._registry.append(self)
         return self
 
-    def __init__(self, fedb_series=None, fedb_tag=None, *, angle=0, side=None, width=None,
+    def __init__(self, fedb_series=None, fedb_tag=None, container=None, *, angle=0, side=None, width=None,
                  height=None, length=None, material=None, info=None, extra_commands=None,
                  is_crystal=False, bending_radius=None, _allow_generic=False, is_broken=False,
                  _force_init=False, **kwargs):
@@ -61,6 +61,7 @@ class FlukaPrototype:
         if self._is_null:
             self._fedb_series = None
             self._fedb_tag = None
+            self._container = None
             self._name = None
             self._side = None
             self._angle = None
@@ -83,6 +84,7 @@ class FlukaPrototype:
         self._fedb_series = fedb_series
         self._fedb_tag = fedb_tag
         self._name = fedb_tag
+        self._container = container
         if side is not None:
             BaseCollimator.side.fset(self, side)  # This will overwrite the side in the FlukaCollimator
         else:
@@ -177,6 +179,7 @@ class FlukaPrototype:
             'name': self.name,
             'fedb_series': self.fedb_series,
             'fedb_tag': self.fedb_tag,
+            'container': self.container,
             'side': self.side,
             'angle': self.angle,
             'length': self.length,
@@ -237,6 +240,12 @@ class FlukaPrototype:
         if self._is_null:
             return None
         return self._fedb_tag
+
+    @property
+    def container(self):
+        if self._is_null:
+            return None
+        return self._container
 
     @property
     def body_file(self):
@@ -453,6 +462,8 @@ class FlukaPrototype:
         prot  = f"{_type:9}     {self.name}\n"
         prot += f"FEDB_SERIES   {self.fedb_series}\n"
         prot += f"FEDB_TAG      {self.fedb_tag}\n"
+        if isinstance(self, FlukaPrototype):
+            prot += f"CONTAINER     {self.container}\n"
         prot += f"ROT-DEFI  "
         self._idx = idx  # Store the index for fluka_position property
         for value in self.fluka_position:


### PR DESCRIPTION
- Include 'container' needed when prototypes are used instead of assemblies. Without these extra command in the prototypes.ldp, the volume that contains the prototypes is not produce correctly in FLUKA.
- In this context, for the beam beam routine, the IPPIPE prototype was necessary. In the metadata an extra key "container" was added.
- XXX The material file in FEDB has vacuum for the pipe material.. Should be communicated to the FLUKA team.
- In the checking for the filtering algorithm, vacuum was replace for IPPIPE.
-  An example to use the beam beam routine was included in the examples dir.
- Finally, there is also the patch done with Giacomo, where installing fluka collimation was crashing due to the required interative property in "at".