### PR TITLE
Release 0.10.0

### DIFF
--- a/examples/adt.py
+++ b/examples/adt.py
@@ -54,18 +54,18 @@ tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
 tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
 tt = line.get_table()
 adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
-adt = xc.BlowUp.install(line, name=f'{name}_blowup', at_s=adt_pos, need_apertures=False, plane=plane,
+adt = xc.BlowUp.install(line, name=f'{name}_blowup', at=adt_pos, need_apertures=False, plane=plane,
                         stop_at_turn=adt_turns)
 
 
 # Add an emittance monitor
-mon = xc.EmittanceMonitor.install(line, name="emittance monitor", at_s=adt_pos, stop_at_turn=total_turns)
+mon = xc.EmittanceMonitor.install(line, name="emittance monitor", at=adt_pos, stop_at_turn=total_turns)
 
 
 # We also add a particles monitor, to calculate the emittance based on normalised coordinates.
 # This will allow us to see how strongly the beam is mismatched.
 mon2 = xt.ParticlesMonitor(start_at_turn=0, stop_at_turn=total_turns, num_particles=num_particles)
-line.insert_element(element=mon2, name="particle monitor", at_s=adt_pos)
+line.insert("particle monitor", mon2, at=adt_pos)
 
 
 # Build the tracker and optimise

--- a/examples/adt.py
+++ b/examples/adt.py
@@ -52,7 +52,8 @@ pos = 'b5l4' if f'{beam}' == '2' and plane == 'V' else pos
 name = f'adtk{plane.lower()}.{pos}.b{beam}'
 tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
 tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
-adt_pos = 0.5*line.get_s_position(tank_start) + 0.5*line.get_s_position(tank_end)
+tt = line.get_table()
+adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
 adt = xc.BlowUp.install(line, name=f'{name}_blowup', at_s=adt_pos, need_apertures=False, plane=plane,
                         stop_at_turn=adt_turns)
 

--- a/examples/adt_simplified.py
+++ b/examples/adt_simplified.py
@@ -42,7 +42,8 @@ pos = 'b5l4' if f'{beam}' == '2' and plane == 'V' else pos
 name = f'adtk{plane.lower()}.{pos}.b{beam}'
 tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
 tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
-adt_pos = 0.5*line.get_s_position(tank_start) + 0.5*line.get_s_position(tank_end)
+tt = line.get_table()
+adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
 adt = xc.BlowUp.install(line, name=f'{name}_blowup', at_s=adt_pos, need_apertures=False, plane=plane,
                         stop_at_turn=adt_turns, use_individual_kicks=True)
 

--- a/examples/adt_simplified.py
+++ b/examples/adt_simplified.py
@@ -44,18 +44,18 @@ tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
 tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
 tt = line.get_table()
 adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
-adt = xc.BlowUp.install(line, name=f'{name}_blowup', at_s=adt_pos, need_apertures=False, plane=plane,
+adt = xc.BlowUp.install(line, name=f'{name}_blowup', at=adt_pos, need_apertures=False, plane=plane,
                         stop_at_turn=adt_turns, use_individual_kicks=True)
 
 
 # Add an emittance monitor
-mon = xc.EmittanceMonitor.install(line, name="emittance monitor", at_s=adt_pos, stop_at_turn=total_turns)
+mon = xc.EmittanceMonitor.install(line, name="emittance monitor", at=adt_pos, stop_at_turn=total_turns)
 
 
 # We also add a particles monitor, to calculate the emittance based on normalised coordinates.
 # This will allow us to see how strongly the beam is mismatched.
 mon2 = xt.ParticlesMonitor(start_at_turn=0, stop_at_turn=total_turns, num_particles=num_particles)
-line.insert_element(element=mon2, name="particle monitor", at_s=adt_pos)
+line.insert("particle monitor", mon2, at=adt_pos)
 
 
 # Build the tracker and optimise

--- a/examples/everest_collimator.py
+++ b/examples/everest_collimator.py
@@ -35,7 +35,7 @@ line = env[f'lhcb{beam}']
 TCPH = xc.EverestCollimator(length=0.6, gap=5, material=xc.materials.MolybdenumGraphite, emittance=3.5e-6)
 TCPV = xc.EverestCollimator(length=0.6, gap=5, material=xc.materials.MolybdenumGraphite, angle=90, emittance=3.5e-6)
 TCPS = xc.EverestCollimator(length=0.6, gap=5, material=xc.materials.Carbon, angle=127.5, emittance=3.5e-6)
-line.collimators.install(['tcp.c6l7.b1', 'tcp.d6l7.b1', 'tcp.b6l7.b1'], [TCPH, TCPV, TCPS], need_apertures=False)
+line.xcoll.collimators.install(['tcp.c6l7.b1', 'tcp.d6l7.b1', 'tcp.b6l7.b1'], [TCPH, TCPV, TCPS], need_apertures=False)
 
 
 # Aperture model check
@@ -49,7 +49,7 @@ line.build_tracker()
 
 
 # Assign the optics to deduce the gap settings
-line.collimators.assign_optics()
+line.xcoll.collimators.assign_optics()
 
 
 # --------------------------------------------------------
@@ -73,9 +73,9 @@ part = line.build_particles(x_norm=x_norm, y_norm=y_norm,
 
 # Track
 print("Tracking first test.. ")
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part, num_turns=1)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 
 # Sort the particles by their ID
 part.sort(interleave_lost_particles=True)
@@ -102,7 +102,7 @@ plt.show()
 # oscillations would make the cut profile symmetric anyway.
 
 line['tcp.c6l7.b1'].angle = 15
-line.collimators.open()
+line.xcoll.collimators.open()
 line['tcp.c6l7.b1'].gap = [4, -7]
 
 # Create initial particles
@@ -113,9 +113,9 @@ part = line.build_particles(x_norm=x_norm, y_norm=y_norm,
 
 # Track
 print("Tracking second test.. ")
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part, num_turns=1)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 
 # Sort the particles by their ID
 part.sort(interleave_lost_particles=True)

--- a/examples/fluka_lossmap.py
+++ b/examples/fluka_lossmap.py
@@ -42,7 +42,7 @@ assert not np.any(df_with_coll.has_aperture_problem)
 
 
 # Assign the optics to deduce the gap settings
-line.collimators.assign_optics()
+line.xcoll.collimators.assign_optics()
 
 
 # Connect to FLUKA
@@ -61,9 +61,9 @@ part = line[tcp].generate_pencil(num_particles)
 
 
 # Track!
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part, num_turns=num_turns, time=True, with_progress=1)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 print(f"Done tracking in {line.time_last_track:.1f}s.")
 
 

--- a/examples/fluka_lossmap_with_crystals.py
+++ b/examples/fluka_lossmap_with_crystals.py
@@ -51,8 +51,8 @@ tcpc = f"tcpc{plane.lower()}.a{6 if plane=='V' else 4 if f'{beam}'=='1' else 5}{
 
 
 # Assign the optics to deduce the gap settings
-line.collimators.assign_optics()
-line.collimators.align_to_beam_divergence()
+line.xcoll.collimators.assign_optics()
+line.xcoll.collimators.align_to_beam_divergence()
 
 
 # Connect to FLUKA
@@ -83,9 +83,9 @@ line.build_tracker(_context=xo.ContextCpu(omp_num_threads='auto'))
 
 
 # Track!
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part, num_turns=num_turns, time=True, with_progress=1)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 print(f"Done tracking in {line.time_last_track:.1f}s.")
 
 

--- a/examples/geant4_lossmap.py
+++ b/examples/geant4_lossmap.py
@@ -43,7 +43,7 @@ assert not np.any(df_with_coll.has_aperture_problem)
 
 
 # Assign the optics to deduce the gap settings
-line.collimators.assign_optics()
+line.xcoll.collimators.assign_optics()
 
 
 # Connect to Geant4
@@ -62,9 +62,9 @@ part = line[tcp].generate_pencil(num_particles)
 
 
 # Track!
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part, num_turns=num_turns, time=True, with_progress=1)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 print(f"Done tracking in {line.time_last_track:.1f}s.")
 
 

--- a/examples/impacts.py
+++ b/examples/impacts.py
@@ -27,7 +27,7 @@ impacts = xc.InteractionRecord.start(line=line)
 
 # Build tracker, assign optics and generate particles 
 line.build_tracker()
-line.collimators.assign_optics()
+line.xcoll.collimators.assign_optics()
 part = line['tcp.d6l7.b1'].generate_pencil(5000)
 
 # This is not needed, but is done here so that we can track with 12 treads.
@@ -35,9 +35,9 @@ line.discard_tracker()
 line.build_tracker(_context=xo.ContextCpu(omp_num_threads=12))
 
 # Track
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part, num_turns=20, time=True, with_progress=1)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 line.discard_tracker()
 impacts.stop()
 

--- a/examples/lossmap.py
+++ b/examples/lossmap.py
@@ -43,7 +43,7 @@ assert not np.any(df_with_coll.has_aperture_problem)
 
 
 # Assign the optics to deduce the gap settings
-line.collimators.assign_optics()
+line.xcoll.collimators.assign_optics()
 
 
 # Optimise the line
@@ -62,9 +62,9 @@ line.build_tracker(_context=xo.ContextCpu(omp_num_threads='auto'))
 
 
 # Track!
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part, num_turns=num_turns, time=True, with_progress=1)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 print(f"Done tracking in {line.time_last_track:.1f}s.")
 
 

--- a/examples/lossmap_blowup.py
+++ b/examples/lossmap_blowup.py
@@ -47,7 +47,7 @@ tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
 tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
 tt = line.get_table()
 adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
-adt = xc.BlowUp.install(line, name=f'{name}_blowup', at_s=adt_pos, plane=plane, stop_at_turn=num_turns,
+adt = xc.BlowUp.install(line, name=f'{name}_blowup', at=adt_pos, plane=plane, stop_at_turn=num_turns,
                         amplitude=0.5, use_individual_kicks=True)
 
 

--- a/examples/lossmap_blowup.py
+++ b/examples/lossmap_blowup.py
@@ -59,7 +59,7 @@ assert not np.any(df_with_coll.has_aperture_problem)
 
 # Assign the optics to deduce the gap settings, and calibrate the ADT
 tw = line.twiss()
-line.collimators.assign_optics(twiss=tw)
+line.xcoll.collimators.assign_optics(twiss=tw)
 if plane == 'H':
     adt.calibrate_by_emittance(nemitt=colldb.nemitt_x, twiss=tw)
 else:
@@ -82,11 +82,11 @@ line.build_tracker(_context=xo.ContextCpu(omp_num_threads='auto'))
 
 
 # Track!
-line.scattering.enable()
+line.xcoll.scattering.enable()
 adt.activate()
 line.track(part, num_turns=num_turns, time=True, with_progress=1)
 adt.deactivate()
-line.scattering.disable()
+line.xcoll.scattering.disable()
 print(f"Done tracking in {line.time_last_track:.1f}s.")
 
 

--- a/examples/lossmap_blowup.py
+++ b/examples/lossmap_blowup.py
@@ -45,7 +45,8 @@ pos = 'b5l4' if f'{beam}' == '2' and plane == 'V' else pos
 name = f'adtk{plane.lower()}.{pos}.b{beam}'
 tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
 tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
-adt_pos = 0.5*line.get_s_position(tank_start) + 0.5*line.get_s_position(tank_end)
+tt = line.get_table()
+adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
 adt = xc.BlowUp.install(line, name=f'{name}_blowup', at_s=adt_pos, plane=plane, stop_at_turn=num_turns,
                         amplitude=0.5, use_individual_kicks=True)
 

--- a/examples/lossmap_offmomentum.py
+++ b/examples/lossmap_offmomentum.py
@@ -46,7 +46,7 @@ assert not np.any(df_with_coll.has_aperture_problem)
 
 
 # Assign the optics to deduce the gap settings
-line.collimators.assign_optics()
+line.xcoll.collimators.assign_optics()
 
 
 # Generate initial matched bunch
@@ -68,9 +68,9 @@ rf_sweep.info()
 
 
 # Track during RF sweep:
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(particles=part, num_turns=num_turns, time=True, with_progress=5)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 print(f"Done sweeping RF in {line.time_last_track:.1f}s.")
 
 

--- a/examples/lossmap_with_crystals.py
+++ b/examples/lossmap_with_crystals.py
@@ -49,8 +49,8 @@ tcpc = f"tcpc{plane.lower()}.a{6 if plane=='V' else 4 if f'{beam}'=='1' else 5}{
 
 
 # Assign the optics to deduce the gap settings
-line.collimators.assign_optics()
-line.collimators.align_to_beam_divergence()
+line.xcoll.collimators.assign_optics()
+line.xcoll.collimators.align_to_beam_divergence()
 
 
 # Optimise the line
@@ -77,9 +77,9 @@ line.build_tracker(_context=xo.ContextCpu(omp_num_threads='auto'))
 
 
 # Track!
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part, num_turns=num_turns, time=True, with_progress=1)
-line.scattering.disable()
+line.xcoll.scattering.disable()
 print(f"Done tracking in {line.time_last_track:.1f}s.")
 
 

--- a/examples/machines/sps_q20_inj.json
+++ b/examples/machines/sps_q20_inj.json
@@ -8562,7 +8562,7 @@
   },
   "actcse.31632": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8571,7 +8571,7 @@
   },
   "actcse.31637": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8580,7 +8580,7 @@
   },
   "actcse.31654": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8593,7 +8593,7 @@
   },
   "actcsf.31672": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8602,7 +8602,7 @@
   },
   "actcsf.31678": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8611,7 +8611,7 @@
   },
   "actcsf.31695": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8663,7 +8663,7 @@
   },
   "acl.31735": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 3.52913,
    "_model": 0,
    "_integrator": 0,
@@ -8676,7 +8676,7 @@
   },
   "actcsg.31751": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8685,7 +8685,7 @@
   },
   "actcsg.31758": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8694,7 +8694,7 @@
   },
   "actcsg.31774": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8703,7 +8703,7 @@
   },
   "actcsg.31780": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8754,7 +8754,7 @@
   },
   "actcsh.31832": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8763,7 +8763,7 @@
   },
   "actcsh.31838": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8772,7 +8772,7 @@
   },
   "actcsh.31854": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8785,7 +8785,7 @@
   },
   "actcsi.31872": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8794,7 +8794,7 @@
   },
   "actcsi.31878": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8803,7 +8803,7 @@
   },
   "actcsi.31895": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8847,7 +8847,7 @@
   },
   "acl.31936": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 3.52913,
    "_model": 0,
    "_integrator": 0,
@@ -8860,7 +8860,7 @@
   },
   "actcsj.31952": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8869,7 +8869,7 @@
   },
   "actcsj.31958": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8878,7 +8878,7 @@
   },
   "actcsj.31974": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -8887,7 +8887,7 @@
   },
   "actcsj.31991": {
    "__class__": "Cavity",
-   "lag": 180.0,
+   "phase": 3.141592653589793,
    "length": 4.114,
    "_model": 0,
    "_integrator": 0,
@@ -33354,8 +33354,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcse.31632'].lag",
-   "vars['lag200']"
+   "element_refs['actcse.31632'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcse.31637'].frequency",
@@ -33366,8 +33366,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcse.31637'].lag",
-   "vars['lag200']"
+   "element_refs['actcse.31637'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcse.31654'].frequency",
@@ -33378,8 +33378,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcse.31654'].lag",
-   "vars['lag200']"
+   "element_refs['actcse.31654'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsf.31672'].frequency",
@@ -33390,8 +33390,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsf.31672'].lag",
-   "vars['lag200']"
+   "element_refs['actcsf.31672'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsf.31678'].frequency",
@@ -33402,8 +33402,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsf.31678'].lag",
-   "vars['lag200']"
+   "element_refs['actcsf.31678'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsf.31695'].frequency",
@@ -33414,8 +33414,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsf.31695'].lag",
-   "vars['lag200']"
+   "element_refs['actcsf.31695'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsg.31751'].frequency",
@@ -33426,8 +33426,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsg.31751'].lag",
-   "vars['lag200']"
+   "element_refs['actcsg.31751'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsg.31758'].frequency",
@@ -33438,8 +33438,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsg.31758'].lag",
-   "vars['lag200']"
+   "element_refs['actcsg.31758'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsg.31774'].frequency",
@@ -33450,8 +33450,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsg.31774'].lag",
-   "vars['lag200']"
+   "element_refs['actcsg.31774'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsg.31780'].frequency",
@@ -33462,8 +33462,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsg.31780'].lag",
-   "vars['lag200']"
+   "element_refs['actcsg.31780'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsh.31832'].frequency",
@@ -33474,8 +33474,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsh.31832'].lag",
-   "vars['lag200']"
+   "element_refs['actcsh.31832'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsh.31838'].frequency",
@@ -33486,8 +33486,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsh.31838'].lag",
-   "vars['lag200']"
+   "element_refs['actcsh.31838'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsh.31854'].frequency",
@@ -33498,8 +33498,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsh.31854'].lag",
-   "vars['lag200']"
+   "element_refs['actcsh.31854'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsi.31872'].frequency",
@@ -33510,8 +33510,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsi.31872'].lag",
-   "vars['lag200']"
+   "element_refs['actcsi.31872'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsi.31878'].frequency",
@@ -33522,8 +33522,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsi.31878'].lag",
-   "vars['lag200']"
+   "element_refs['actcsi.31878'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsi.31895'].frequency",
@@ -33534,8 +33534,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsi.31895'].lag",
-   "vars['lag200']"
+   "element_refs['actcsi.31895'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsj.31952'].frequency",
@@ -33546,8 +33546,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsj.31952'].lag",
-   "vars['lag200']"
+   "element_refs['actcsj.31952'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsj.31958'].frequency",
@@ -33558,8 +33558,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsj.31958'].lag",
-   "vars['lag200']"
+   "element_refs['actcsj.31958'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsj.31974'].frequency",
@@ -33570,8 +33570,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsj.31974'].lag",
-   "vars['lag200']"
+   "element_refs['actcsj.31974'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['actcsj.31991'].frequency",
@@ -33582,8 +33582,8 @@
    "(vars['volt200'] / 20.0)"
   ],
   [
-   "element_refs['actcsj.31991'].lag",
-   "vars['lag200']"
+   "element_refs['actcsj.31991'].phase",
+   "(0.017453292519943295 * vars['lag200'])"
   ],
   [
    "element_refs['acl.31735'].frequency",
@@ -33594,8 +33594,8 @@
    "(vars['volt800'] / 2.0)"
   ],
   [
-   "element_refs['acl.31735'].lag",
-   "vars['lag800']"
+   "element_refs['acl.31735'].phase",
+   "(0.017453292519943295 * vars['lag800'])"
   ],
   [
    "element_refs['acl.31936'].frequency",
@@ -33606,8 +33606,8 @@
    "(vars['volt800'] / 2.0)"
   ],
   [
-   "element_refs['acl.31936'].lag",
-   "vars['lag800']"
+   "element_refs['acl.31936'].phase",
+   "(0.017453292519943295 * vars['lag800'])"
   ]
  ],
  "metadata": {},

--- a/examples/transfer_line_with_air.py
+++ b/examples/transfer_line_with_air.py
@@ -95,8 +95,9 @@ print("Done Tracking!")
 # ===============
 _, ax = plt.subplots(figsize=(6,4))
 s = [0, 20, 30, 50, 60, 100]
-ex = np.array([el.nemitt_x for el in line.get_elements_of_type(xc.EmittanceMonitor)[0]])
-ey = np.array([el.nemitt_y for el in line.get_elements_of_type(xc.EmittanceMonitor)[0]])
+tt_mon = line.get_table().rows.match(element_type='EmittanceMonitor')
+ex = np.array([line[name].nemitt_x for name in tt_mon.name])
+ey = np.array([line[name].nemitt_y for name in tt_mon.name])
 ax.plot(s, 1.e6*ex, label='H')
 ax.plot(s, 1.e6*ey, label='V')
 ax.set_ylabel(r"$\epsilon_N\; [\mu\mathrm{m}]$")

--- a/examples/transfer_line_with_air.py
+++ b/examples/transfer_line_with_air.py
@@ -60,7 +60,7 @@ xc.EmittanceMonitor.install(line, name="monitor end", at_s=100, longitudinal=Fal
 # Generate an initial distribution of particles
 # =============================================
 # Scattering need to be disabled to be able to twiss
-line.scattering.disable()
+line.xcoll.scattering.disable()
 
 # Matched initial parameters
 betx0 = 154.0835045206266
@@ -86,7 +86,7 @@ part = line.build_particles(x_norm=x_norm, px_norm=px_norm, y_norm=y_norm, py_no
 
 # Track!
 # ======
-line.scattering.enable()
+line.xcoll.scattering.enable()
 line.track(part)
 print("Done Tracking!")
 

--- a/examples/transfer_line_with_air.py
+++ b/examples/transfer_line_with_air.py
@@ -43,18 +43,20 @@ line = xt.Line(elements=elements, element_names=element_names, particle_ref=part
 
 # Add air regions
 # ===============
-line.insert_element(element=xc.EverestBlock(length=10, material=xc.materials.Air), name="Air 1", at_s=20)
-line.insert_element(element=xc.EverestBlock(length=10, material=xc.materials.Air), name="Air 2", at_s=50)
+line.insert("Air 1", xc.EverestBlock(length=10, material=xc.materials.Air),
+            anchor='start', at=20)
+line.insert("Air 2", xc.EverestBlock(length=10, material=xc.materials.Air),
+            anchor='start', at=50)
 
 
 # Add monitors
 # ============
-xc.EmittanceMonitor.install(line, name="monitor start", at_s=0, longitudinal=False)
-xc.EmittanceMonitor.install(line, name="monitor air 1 start", at_s=20, longitudinal=False)
-xc.EmittanceMonitor.install(line, name="monitor air 1 end", at_s=30, longitudinal=False)
-xc.EmittanceMonitor.install(line, name="monitor air 2 start", at_s=50, longitudinal=False)
-xc.EmittanceMonitor.install(line, name="monitor air 2 end", at_s=60, longitudinal=False)
-xc.EmittanceMonitor.install(line, name="monitor end", at_s=100, longitudinal=False)
+xc.EmittanceMonitor.install(line, name="monitor start", at=0, longitudinal=False)
+xc.EmittanceMonitor.install(line, name="monitor air 1 start", at=20, longitudinal=False)
+xc.EmittanceMonitor.install(line, name="monitor air 1 end", at=30, longitudinal=False)
+xc.EmittanceMonitor.install(line, name="monitor air 2 start", at=50, longitudinal=False)
+xc.EmittanceMonitor.install(line, name="monitor air 2 end", at=60, longitudinal=False)
+xc.EmittanceMonitor.install(line, name="monitor end", at=100, longitudinal=False)
 
 
 # Generate an initial distribution of particles

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xcoll"
-version = "0.9.12"
+version = "0.10.0rc0"
 description = "Xsuite collimation package"
 authors = [
     {name="Frederik F. Van der Veken", email="frederik@cern.ch"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xcoll"
-version = "0.10.0rc0"
+version = "0.10.0"
 description = "Xsuite collimation package"
 authors = [
     {name="Frederik F. Van der Veken", email="frederik@cern.ch"},
@@ -22,10 +22,10 @@ dependencies = [
     "ruamel-yaml>=0.17.31",
     "numpy>=1.0",
     "pandas>=1.4",
-    "xobjects>=0.5.15",
-    "xdeps>=0.10.16",
-    "xpart>=0.23.10",
-    "xtrack>=0.102.1",
+    "xobjects>=0.6.3",
+    "xdeps>=0.10.17",
+    "xpart>=0.23.12",
+    "xtrack>=0.104.2",
     "meson"
 ]
 

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -ra -vv --durations=10 --durations-min=1 --html=pytest_results.html --maxschedchunk=1
+addopts = -ra -vv --durations=10 --durations-min=1 --html=pytest_results.html --maxschedchunk=1 --ignore-glob='**/test_assembly.py'
 generate_report_on_test = True
 render_collapsed = all
 markers =

--- a/tests/test_blowup_and_monitor.py
+++ b/tests/test_blowup_and_monitor.py
@@ -202,7 +202,8 @@ def test_blowup_install(beam, plane, aper, test_context):
     name = f'adtk{plane.lower()}.{pos}.b{beam}'
     tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
     tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
-    adt_pos = 0.5*line.get_s_position(tank_start) + 0.5*line.get_s_position(tank_end)
+    tt = line.get_table()
+    adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
     xc.BlowUp.install(line, name=f'{name}_blowup', at=adt_pos, need_apertures=need_apertures,
                       aperture=aperture, plane=plane, stop_at_turn=num_turns,
                       use_individual_kicks=True, _context=test_context)
@@ -220,7 +221,8 @@ def test_blowup(beam, plane, test_context):
     name = f'adtk{plane.lower()}.{pos}.b{beam}'
     tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
     tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
-    adt_pos = 0.5*line.get_s_position(tank_start) + 0.5*line.get_s_position(tank_end)
+    tt = line.get_table()
+    adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
     adt = xc.BlowUp.install(line, name=f'{name}_blowup', at=adt_pos, need_apertures=False, plane=plane,
                             stop_at_turn=num_turns, use_individual_kicks=True, _context=test_context)
     mon = xc.EmittanceMonitor.install(line, name="monitor", at=adt_pos, stop_at_turn=num_turns, _context=test_context)
@@ -268,7 +270,8 @@ def test_monitor_reset(test_context):
     name = f'adtk{plane.lower()}.{pos}.b{beam}'
     tank_start = f'adtk{plane.lower()}.{pos}.a.b{beam}'
     tank_end   = f'adtk{plane.lower()}.{pos}.d.b{beam}'
-    adt_pos = 0.5*line.get_s_position(tank_start) + 0.5*line.get_s_position(tank_end)
+    tt = line.get_table()
+    adt_pos = 0.5*tt['s', tank_start] + 0.5*tt['s', tank_end]
     adt = xc.BlowUp.install(line, name=f'{name}_blowup', at=adt_pos, need_apertures=False, plane=plane,
                             stop_at_turn=num_turns, use_individual_kicks=True)
     mon = xc.EmittanceMonitor.install(line, name="monitor", at=adt_pos, stop_at_turn=num_turns)

--- a/tests/test_environment_tools.py
+++ b/tests/test_environment_tools.py
@@ -10,5 +10,4 @@ import xcoll as xc
 def test_environment_api_facade():
     env = xt.Environment()
     assert isinstance(env.xcoll, xc.XcollEnvironmentAPI)
-    assert env.xcoll is env.xcoll
     assert env.xcoll._env is env

--- a/tests/test_environment_tools.py
+++ b/tests/test_environment_tools.py
@@ -1,0 +1,14 @@
+# copyright ############################### #
+# This file is part of the Xcoll package.   #
+# Copyright (c) CERN, 2026.                 #
+# ######################################### #
+
+import xtrack as xt
+import xcoll as xc
+
+
+def test_environment_api_facade():
+    env = xt.Environment()
+    assert isinstance(env.xcoll, xc.XcollEnvironmentAPI)
+    assert env.xcoll is env.xcoll
+    assert env.xcoll._env is env

--- a/tests/test_fluka_input.py
+++ b/tests/test_fluka_input.py
@@ -140,7 +140,10 @@ def test_fluka_input_line(ignore_crystals):
     colldb = xc.CollimatorDatabase.from_yaml(path / 'data' / f'colldb_lhc_run3_ir7.yaml', beam=beam,
                                              ignore_crystals=ignore_crystals)
     colldb.install_fluka_collimators(line=line, verbose=True)
-    colls, _ = line.get_elements_of_type(xc.collimator_classes)
+    tt_colls = line.get_table().rows.match(
+        element_type='|'.join(cc.__name__ for cc in xc.collimator_classes)
+    )
+    colls = [line[name] for name in tt_colls.name]
     line.build_tracker()
     line.collimators.assign_optics()
     if not ignore_crystals:

--- a/tests/test_fluka_input.py
+++ b/tests/test_fluka_input.py
@@ -145,9 +145,9 @@ def test_fluka_input_line(ignore_crystals):
     )
     colls = [line[name] for name in tt_colls.name]
     line.build_tracker()
-    line.collimators.assign_optics()
+    line.xcoll.collimators.assign_optics()
     if not ignore_crystals:
-        line.collimators.align_to_beam_divergence()
+        line.xcoll.collimators.align_to_beam_divergence()
     path_tmp = Path.cwd() / f'temp_fluka_test_line_{ignore_crystals}'
     particle_ref = xt.Particles('proton', p0c=7e12)
     input_file = xc.fluka.engine.generate_input_file(line=line, clean=False, cwd=path_tmp,

--- a/tests/test_impacts.py
+++ b/tests/test_impacts.py
@@ -37,16 +37,16 @@ def test_impacts_from_line(beam, plane, test_context):
     impacts = xc.InteractionRecord.start(line=line, record_impacts=True, record_exits=True)
     line.build_tracker(_context=test_context)
 
-    line.collimators.assign_optics()
+    line.xcoll.collimators.assign_optics()
     tcp  = f"tcp.{'c' if plane=='H' else 'd'}6{'l' if beam==1 else 'r'}7.b{beam}"
     tw = line.twiss()
     part = line[tcp].generate_pencil(num_part, twiss=tw)
 
-    line.scattering.enable()
+    line.xcoll.scattering.enable()
     line.track(part, num_turns=num_turns, time=True, with_progress=1)
-    line.scattering.disable()
+    line.xcoll.scattering.disable()
 
-    _assert_impacts(impacts, lengths=line.collimators.length)
+    _assert_impacts(impacts, lengths=line.xcoll.collimators.length)
 
 
 @for_all_test_contexts(

--- a/tests/test_initial_distribution.py
+++ b/tests/test_initial_distribution.py
@@ -39,7 +39,7 @@ def test_create_initial_distribution(beam, npart,impact_parameter, pencil_spread
 
     colldb.install_everest_collimators(line=line)
     line.build_tracker()
-    line.collimators.assign_optics()
+    line.xcoll.collimators.assign_optics()
 
     tw = line.twiss()
     tcp_conv = f"tcp.c6{'l' if beam == 1 else 'r'}7.b{beam}"

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -47,11 +47,13 @@ def test_install_single_existing_marker(beam, aper, test_context):
     # Test absorber
     name = 'tcp.b6l7.b1' if beam == 1 else 'tcp.b6r7.b2'
     assert not isinstance(line[name], xc.BlackAbsorber)
-    pos_centre = line.get_s_position(name) + line[name].length/2
+    tt = line.get_table()
+    pos_centre = tt['s', name] + line[name].length/2
     coll = xc.BlackAbsorber(length=0.6, angle=127.5, _context=test_context)
     line.collimators.install(name, coll, apertures=aperture, need_apertures=need_apertures)
     assert np.isclose(line[name].length, 0.6)
-    assert np.isclose(pos_centre - line[name].length/2, line.get_s_position(name))
+    assert np.isclose(pos_centre - line[name].length/2,
+                      line.get_table()['s', name])
     assert isinstance(line[name], xc.BlackAbsorber)
     tab = line.get_table()
     if need_apertures:
@@ -81,12 +83,14 @@ def test_install_single_existing_marker(beam, aper, test_context):
             assert line[idx].length > existing_length/2
             line[idx].length -= existing_length/2
             break
-    pos_centre = line.get_s_position(name) + line[name].length/2
+    tt = line.get_table()
+    pos_centre = tt['s', name] + line[name].length/2
     coll = xc.EverestCollimator(length=0.6, angle=90, _context=test_context,
                                 material=xc.materials.MolybdenumGraphite)
     line.collimators.install(name, coll, apertures=aperture, need_apertures=need_apertures)
     assert np.isclose(line[name].length, 0.6)
-    assert np.isclose(pos_centre - line[name].length/2, line.get_s_position(name))
+    assert np.isclose(pos_centre - line[name].length/2,
+                      line.get_table()['s', name])
     assert isinstance(line[name], xc.EverestCollimator)
     tab = line.get_table()
     if need_apertures:
@@ -115,7 +119,7 @@ def test_install_single_no_marker(beam, test_context):
                              apertures=xt.LimitEllipse(0.4, 0.4))
     assert name in line.element_names
     assert np.isclose(line[name].length, 1.738)
-    assert np.isclose(line.get_s_position(name), 12.4)
+    assert np.isclose(line.get_table()['s', name], 12.4)
     assert isinstance(line[name], xc.BlackAbsorber)
     tab = line.get_table()
     idx = tab.rows.indices[[name]][0]
@@ -135,7 +139,7 @@ def test_install_single_no_marker(beam, test_context):
     line.collimators.install(name, el, need_apertures=False, at=17.89)
     assert name in line.element_names
     assert np.isclose(line[name].length, 0.63)
-    assert np.isclose(line.get_s_position(name), 17.89)
+    assert np.isclose(line.get_table()['s', name], 17.89)
     assert isinstance(line[name], xc.EverestBlock)
 
     # Verify line length did not corrupt

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -50,7 +50,7 @@ def test_install_single_existing_marker(beam, aper, test_context):
     tt = line.get_table()
     pos_centre = tt['s', name] + line[name].length/2
     coll = xc.BlackAbsorber(length=0.6, angle=127.5, _context=test_context)
-    line.collimators.install(name, coll, apertures=aperture, need_apertures=need_apertures)
+    line.xcoll.collimators.install(name, coll, apertures=aperture, need_apertures=need_apertures)
     assert np.isclose(line[name].length, 0.6)
     assert np.isclose(pos_centre - line[name].length/2,
                       line.get_table()['s', name])
@@ -87,7 +87,7 @@ def test_install_single_existing_marker(beam, aper, test_context):
     pos_centre = tt['s', name] + line[name].length/2
     coll = xc.EverestCollimator(length=0.6, angle=90, _context=test_context,
                                 material=xc.materials.MolybdenumGraphite)
-    line.collimators.install(name, coll, apertures=aperture, need_apertures=need_apertures)
+    line.xcoll.collimators.install(name, coll, apertures=aperture, need_apertures=need_apertures)
     assert np.isclose(line[name].length, 0.6)
     assert np.isclose(pos_centre - line[name].length/2,
                       line.get_table()['s', name])
@@ -115,7 +115,7 @@ def test_install_single_no_marker(beam, test_context):
     name = 'test_absorber'
     assert name not in line.element_names
     coll = xc.BlackAbsorber(length=1.738, angle=127.5, _context=test_context)
-    line.collimators.install(name, coll, at=12.4, need_apertures=True,
+    line.xcoll.collimators.install(name, coll, at=12.4, need_apertures=True,
                              apertures=xt.LimitEllipse(0.4, 0.4))
     assert name in line.element_names
     assert np.isclose(line[name].length, 1.738)
@@ -136,7 +136,7 @@ def test_install_single_no_marker(beam, test_context):
     name = 'test_block'
     assert name not in line.element_names
     el = xc.EverestBlock(length=0.63, material=xc.materials.Silicon, _context=test_context)
-    line.collimators.install(name, el, need_apertures=False, at=17.89)
+    line.xcoll.collimators.install(name, el, need_apertures=False, at=17.89)
     assert name in line.element_names
     assert np.isclose(line[name].length, 0.63)
     assert np.isclose(line.get_table()['s', name], 17.89)

--- a/tests/test_jaw_and_gaps.py
+++ b/tests/test_jaw_and_gaps.py
@@ -20,7 +20,7 @@ def test_gaps(beam):
     line = env[f'lhcb{beam}']
     coll = xc.BlackAbsorber(length=1.738, angle=127.5)
     name = 'tcp.b6l7.b1' if beam == 1 else 'tcp.b6r7.b2'
-    line.collimators.install(name, coll, need_apertures=True)
+    line.xcoll.collimators.install(name, coll, need_apertures=True)
     line.build_tracker()
     tw = line.twiss()
     beta_gamma_rel = line.particle_ref._xobject.gamma0[0]*line.particle_ref._xobject.beta0[0]

--- a/tests/test_line_tools.py
+++ b/tests/test_line_tools.py
@@ -18,7 +18,7 @@ path = Path(__file__).parent / 'data'
 def test_line_api_facade():
     line = xt.Line(elements=[], element_names=[])
     assert isinstance(line.xcoll, xc.XcollLineAPI)
-    assert line.xcoll is line.xcoll
+    assert line.xcoll._line is line
 
 
 @for_all_test_contexts(

--- a/tests/test_line_tools.py
+++ b/tests/test_line_tools.py
@@ -23,75 +23,75 @@ def test_line_accessor(beam, test_context):
     env = xt.load(path / f'sequence_lhc_run3_b{beam}.json')
     line = env[f'lhcb{beam}']
     colldb = xc.CollimatorDatabase.from_yaml(path / 'colldb_lhc_run3.yaml', beam=beam)
-    assert str(line.collimators) == ''
-    assert len(line.collimators) == 0
+    assert str(line.xcoll.collimators) == ''
+    assert len(line.xcoll.collimators) == 0
     colldb.install_everest_collimators(verbose=True, line=line)
-    assert str(line.collimators) != ''
+    assert str(line.xcoll.collimators) != ''
     if beam == 1:
-        assert len(line.collimators) == 55
+        assert len(line.xcoll.collimators) == 55
     else:
-        assert len(line.collimators) == 56
+        assert len(line.xcoll.collimators) == 56
     expected_families = {'tcl4', 'tcl5', 'tcl6', 'tct2', 'tdi', 'tcli', 'tcld', 'tcp3',
                          'tcsg3', 'tcla3', 'tct15', 'tcdq', 'tcsp', 'tcp7', 'tcsg7',
                          'tcla7', 'tct8'}
-    assert set(line.collimators.families.keys()) == set(expected_families)
-    assert len(line.collimators['tcp7']) == 3
-    assert len(line.collimators['tcp3']) == 1
-    assert len(line.collimators['tcl4']) == 2
-    assert len(line.collimators['tcl5']) == 2
-    assert len(line.collimators['tcl6']) == 2
-    assert len(line.collimators['tct2']) == 2
-    assert len(line.collimators['tdi']) == 3
-    assert len(line.collimators['tcli']) == 2
-    assert len(line.collimators['tcld']) == 1
-    assert len(line.collimators['tcp3']) == 1
-    assert len(line.collimators['tcsg3']) == 4
-    assert len(line.collimators['tcla3']) == 4
-    assert len(line.collimators['tct15']) == 4
-    assert len(line.collimators['tcdq']) == 3
-    assert len(line.collimators['tcsp']) == 1
-    assert len(line.collimators['tcp7']) == 3
+    assert set(line.xcoll.collimators.families.keys()) == set(expected_families)
+    assert len(line.xcoll.collimators['tcp7']) == 3
+    assert len(line.xcoll.collimators['tcp3']) == 1
+    assert len(line.xcoll.collimators['tcl4']) == 2
+    assert len(line.xcoll.collimators['tcl5']) == 2
+    assert len(line.xcoll.collimators['tcl6']) == 2
+    assert len(line.xcoll.collimators['tct2']) == 2
+    assert len(line.xcoll.collimators['tdi']) == 3
+    assert len(line.xcoll.collimators['tcli']) == 2
+    assert len(line.xcoll.collimators['tcld']) == 1
+    assert len(line.xcoll.collimators['tcp3']) == 1
+    assert len(line.xcoll.collimators['tcsg3']) == 4
+    assert len(line.xcoll.collimators['tcla3']) == 4
+    assert len(line.xcoll.collimators['tct15']) == 4
+    assert len(line.xcoll.collimators['tcdq']) == 3
+    assert len(line.xcoll.collimators['tcsp']) == 1
+    assert len(line.xcoll.collimators['tcp7']) == 3
     if beam == 1:
-        assert len(line.collimators['tcsg7']) == 14
+        assert len(line.xcoll.collimators['tcsg7']) == 14
     else:
-        assert len(line.collimators['tcsg7']) == 15
-    assert len(line.collimators['tcla7']) == 5
-    assert len(line.collimators['tct8']) == 2
+        assert len(line.xcoll.collimators['tcsg7']) == 15
+    assert len(line.xcoll.collimators['tcla7']) == 5
+    assert len(line.xcoll.collimators['tct8']) == 2
     for plane in ['d', 'c', 'b']:
         tcp = f"tcp.{plane}6{'l' if beam==1 else 'r'}7.b{beam}"
-        assert tcp in line.collimators
-        assert tcp in line.collimators['tcp7']
-    assert isinstance(line.collimators.gap, dict)
-    assert np.isclose(line.collimators['tcp7'].length, 0.6)
-    assert np.isclose(line.collimators['tcp7'].gap, 5.0)
-    line.collimators['tcp7'].gap = 8.5
-    assert np.isclose(line.collimators['tcp7'].gap, 8.5)
+        assert tcp in line.xcoll.collimators
+        assert tcp in line.xcoll.collimators['tcp7']
+    assert isinstance(line.xcoll.collimators.gap, dict)
+    assert np.isclose(line.xcoll.collimators['tcp7'].length, 0.6)
+    assert np.isclose(line.xcoll.collimators['tcp7'].gap, 5.0)
+    line.xcoll.collimators['tcp7'].gap = 8.5
+    assert np.isclose(line.xcoll.collimators['tcp7'].gap, 8.5)
     for plane in ['d', 'c', 'b']:
         tcp = f"tcp.{plane}6{'l' if beam==1 else 'r'}7.b{beam}"
         assert np.isclose(line[tcp].gap, 8.5)
-    line.collimators['tcp7'].gap = {f"tcp.c6{'l' if beam==1 else 'r'}7.b{beam}": 5.0,
+    line.xcoll.collimators['tcp7'].gap = {f"tcp.c6{'l' if beam==1 else 'r'}7.b{beam}": 5.0,
                                     f"tcp.d6{'l' if beam==1 else 'r'}7.b{beam}": 5.0}
-    assert isinstance(line.collimators['tcp7'].gap, dict)
-    assert len(list(line.collimators['tcp7'].gap.keys())) == 3
+    assert isinstance(line.xcoll.collimators['tcp7'].gap, dict)
+    assert len(list(line.xcoll.collimators['tcp7'].gap.keys())) == 3
     tcp = f"tcp.d6{'l' if beam==1 else 'r'}7.b{beam}"
-    assert np.isclose(line.collimators.gap[tcp], 5.0)
-    assert np.isclose(line.collimators['tcp7'].gap[tcp], 5.0)
+    assert np.isclose(line.xcoll.collimators.gap[tcp], 5.0)
+    assert np.isclose(line.xcoll.collimators['tcp7'].gap[tcp], 5.0)
     assert np.isclose(line[tcp].gap, 5.0)
     tcp = f"tcp.c6{'l' if beam==1 else 'r'}7.b{beam}"
-    assert np.isclose(line.collimators.gap[tcp], 5.0)
-    assert np.isclose(line.collimators['tcp7'].gap[tcp], 5.0)
+    assert np.isclose(line.xcoll.collimators.gap[tcp], 5.0)
+    assert np.isclose(line.xcoll.collimators['tcp7'].gap[tcp], 5.0)
     assert np.isclose(line[tcp].gap, 5.0)
     tcp = f"tcp.b6{'l' if beam==1 else 'r'}7.b{beam}"
-    assert np.isclose(line.collimators.gap[tcp], 8.5)
-    assert np.isclose(line.collimators['tcp7'].gap[tcp], 8.5)
+    assert np.isclose(line.xcoll.collimators.gap[tcp], 8.5)
+    assert np.isclose(line.xcoll.collimators['tcp7'].gap[tcp], 8.5)
     assert np.isclose(line[tcp].gap, 8.5)
     prev_coll = None
-    for coll in line.collimators:
+    for coll in line.xcoll.collimators:
         assert isinstance(coll, xc.EverestCollimator)
         assert coll._context.__class__ is test_context.__class__
         assert coll is not prev_coll
         prev_coll = coll
-    for name, coll in line.collimators.items():
+    for name, coll in line.xcoll.collimators.items():
         assert isinstance(name, str)
         assert isinstance(coll, xc.EverestCollimator)
         assert coll.name == name

--- a/tests/test_line_tools.py
+++ b/tests/test_line_tools.py
@@ -15,6 +15,12 @@ from xobjects.test_helpers import for_all_test_contexts
 path = Path(__file__).parent / 'data'
 
 
+def test_line_api_facade():
+    line = xt.Line(elements=[], element_names=[])
+    assert isinstance(line.xcoll, xc.XcollLineAPI)
+    assert line.xcoll is line.xcoll
+
+
 @for_all_test_contexts(
     excluding=('ContextCupy', 'ContextPyopencl')  # Rutherford RNG not on GPU
 )

--- a/tests/test_lossmap.py
+++ b/tests/test_lossmap.py
@@ -86,9 +86,9 @@ def test_lossmap(engine, beam, plane, npart, interpolation, ignore_crystals, do_
     df_with_coll = line.check_aperture()
     assert not np.any(df_with_coll.has_aperture_problem)
     line.build_tracker(_context=test_context)
-    line.collimators.assign_optics()
+    line.xcoll.collimators.assign_optics()
     if not ignore_crystals:
-        line.collimators.align_to_beam_divergence()
+        line.xcoll.collimators.align_to_beam_divergence()
 
     if engine == "fluka":
         xc.fluka.engine.start(line=line, capacity=capacity, verbose=True)
@@ -105,9 +105,9 @@ def test_lossmap(engine, beam, plane, npart, interpolation, ignore_crystals, do_
         elif plane == 'V':
             part.y[(part.y > 0) & (part.state > -99999)] += 1e-5
             part.y[(part.y < 0) & (part.state > -99999)] -= 1e-5
-    line.scattering.enable()
+    line.xcoll.scattering.enable()
     line.track(part, num_turns=num_turns, with_progress=1)
-    line.scattering.disable()
+    line.xcoll.scattering.disable()
 
     if engine == "everest":
         coll_cls = ['EverestCollimator']

--- a/tests/test_transfer_line.py
+++ b/tests/test_transfer_line.py
@@ -78,12 +78,12 @@ def _add_air_regions(line):
 
 
 def _add_monitors(line):
-    xc.EmittanceMonitor.install(line, name="monitor start", at_s=0, longitudinal=False)
-    xc.EmittanceMonitor.install(line, name="monitor air 1 start", at_s=20, longitudinal=False)
-    xc.EmittanceMonitor.install(line, name="monitor air 1 end", at_s=30, longitudinal=False)
-    xc.EmittanceMonitor.install(line, name="monitor air 2 start", at_s=50, longitudinal=False)
-    xc.EmittanceMonitor.install(line, name="monitor air 2 end", at_s=60, longitudinal=False)
-    xc.EmittanceMonitor.install(line, name="monitor end", at_s=100, longitudinal=False)
+    xc.EmittanceMonitor.install(line, name="monitor start", at=0, longitudinal=False)
+    xc.EmittanceMonitor.install(line, name="monitor air 1 start", at=20, longitudinal=False)
+    xc.EmittanceMonitor.install(line, name="monitor air 1 end", at=30, longitudinal=False)
+    xc.EmittanceMonitor.install(line, name="monitor air 2 start", at=50, longitudinal=False)
+    xc.EmittanceMonitor.install(line, name="monitor air 2 end", at=60, longitudinal=False)
+    xc.EmittanceMonitor.install(line, name="monitor end", at=100, longitudinal=False)
 
 def _generate_matched_particles(line):
     # Matched initial parameters

--- a/tests/test_transfer_line.py
+++ b/tests/test_transfer_line.py
@@ -35,8 +35,9 @@ def test_transfer_line(test_context):
     part = _generate_matched_particles(line)
     line.scattering.enable()   # Re-enable scattering
     line.track(part)
-    nemitt_x = np.array([el.nemitt_x for el in line.get_elements_of_type(xc.EmittanceMonitor)[0]])
-    nemitt_y = np.array([el.nemitt_y for el in line.get_elements_of_type(xc.EmittanceMonitor)[0]])
+    tt_mon = line.get_table().rows.match(element_type='EmittanceMonitor')
+    nemitt_x = np.array([line[name].nemitt_x for name in tt_mon.name])
+    nemitt_y = np.array([line[name].nemitt_y for name in tt_mon.name])
     assert np.allclose(nemitt_x[0:2],  7.65e-6, atol=1e-7)
     assert np.allclose(nemitt_x[2:4], 10.75e-6, atol=1e-7)
     assert np.allclose(nemitt_x[4:6], 15.68e-6, atol=1e-7)

--- a/tests/test_transfer_line.py
+++ b/tests/test_transfer_line.py
@@ -31,9 +31,9 @@ def test_transfer_line(test_context):
     assert deep_equal(line["Air 2"].material.to_dict(), air.to_dict())
     _add_monitors(line)
     line.build_tracker(_context=test_context)
-    line.scattering.disable()  # Scattering need to be disabled to be able to twiss
+    line.xcoll.scattering.disable()  # Scattering need to be disabled to be able to twiss
     part = _generate_matched_particles(line)
-    line.scattering.enable()   # Re-enable scattering
+    line.xcoll.scattering.enable()   # Re-enable scattering
     line.track(part)
     tt_mon = line.get_table().rows.match(element_type='EmittanceMonitor')
     nemitt_x = np.array([line[name].nemitt_x for name in tt_mon.name])

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@
 from xcoll import __version__
 
 def test_version():
-    assert __version__ == '0.10.0rc0'
+    assert __version__ == '0.10.0'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -6,4 +6,4 @@
 from xcoll import __version__
 
 def test_version():
-    assert __version__ == '0.9.12'
+    assert __version__ == '0.10.0rc0'

--- a/xcoll/__init__.py
+++ b/xcoll/__init__.py
@@ -18,6 +18,7 @@ from .interaction_record import InteractionRecord
 from .rf_sweep import RFSweep, prepare_rf_sweep
 from .lossmap import LossMap, MultiLossMap
 from .particles_tree import ParticlesTree
+from .line_tools import XcollLineAPI
 
 from .constants import particle_states, particle_state_names, interactions, interaction_names
 

--- a/xcoll/__init__.py
+++ b/xcoll/__init__.py
@@ -19,6 +19,7 @@ from .rf_sweep import RFSweep, prepare_rf_sweep
 from .lossmap import LossMap, MultiLossMap
 from .particles_tree import ParticlesTree
 from .line_tools import XcollLineAPI
+from .environment_tools import XcollEnvironmentAPI
 
 from .constants import particle_states, particle_state_names, interactions, interaction_names
 

--- a/xcoll/beam_elements/base.py
+++ b/xcoll/beam_elements/base.py
@@ -1002,7 +1002,7 @@ class BaseCollimator(BaseBlock):
                         longitudinal_betatron_cut=None, tw=None, **kwargs):
         if not hasattr(self, '_line') or not hasattr(self, '_name'):
             raise ValueError("Collimator is missing a pointer to the line. Install collimators "
-                           + "with `line.collimators.install()` (or use "
+                           + "with `line.xcoll.collimators.install()` (or use "
                            + "`xcoll.initial_distribution.generate_pencil_on_collimator()`).")
         from xcoll.initial_distribution import generate_pencil_on_collimator
         return generate_pencil_on_collimator(line=self._line, name=self._name, side=side,
@@ -1015,7 +1015,7 @@ class BaseCollimator(BaseBlock):
                        match_at_front=True, twiss=None):
         if not hasattr(self, '_line') or not hasattr(self, '_name'):
             raise ValueError("Collimator is missing a pointer to the line. Install collimators "
-                           + "with `line.collimators.install()` (or use "
+                           + "with `line.xcoll.collimators.install()` (or use "
                            + "`xcoll.initial_distribution.generate_delta_from_dispersion()`).")
         from xcoll.initial_distribution import generate_delta_from_dispersion
         return generate_delta_from_dispersion(line=self._line, at_element=self._name, plane=plane,

--- a/xcoll/beam_elements/monitor.py
+++ b/xcoll/beam_elements/monitor.py
@@ -529,8 +529,8 @@ class EmittanceMonitor(xt.BeamElement):
                     + f"rank {rank} instead of expected {len(covariance_S)}.\n"
                     + f"{N[i]} particles logged.")
 
-            from xtrack.linear_normal_form import compute_linear_normal_form
-            _, _, _, eigenvalues = compute_linear_normal_form(covariance_S)
+            from xtrack.linear_normal_form import get_linear_normal_form
+            _, _, _, eigenvalues = get_linear_normal_form(covariance_S)
             self._gemitt_I[i] = eigenvalues[0].imag
             self._gemitt_II[i] = eigenvalues[1].imag
             self._gemitt_III[i] = eigenvalues[2].imag

--- a/xcoll/colldb.py
+++ b/xcoll/colldb.py
@@ -499,7 +499,7 @@ class CollimatorDatabase:
             else:
                 at.append(s_center - 0.5*getattr(self, 'length')[name])
             elements.append(self._elements[name])
-        line.collimators.install(names, elements, at=at, apertures=apertures,
+        line.xcoll.collimators.install(names, elements, at=at, apertures=apertures,
                                  need_apertures=need_apertures, s_tol=s_tol)
 
     def install_everest_collimators(self, line, *, names=None, families=None, apertures=None,
@@ -525,7 +525,7 @@ class CollimatorDatabase:
             else:
                 at.append(s_center - 0.5*getattr(self, 'length')[name])
             elements.append(self._elements[name])
-        line.collimators.install(names, elements, at=at, apertures=apertures,
+        line.xcoll.collimators.install(names, elements, at=at, apertures=apertures,
                                  need_apertures=need_apertures, s_tol=s_tol)
 
     def install_fluka_collimators(self, line, *, names=None, families=None, apertures=None,
@@ -567,7 +567,7 @@ class CollimatorDatabase:
             else:
                 self._create_collimator(FlukaCollimator, line, name, material=mat, verbose=verbose, **extra_kwargs)
         elements = [self._elements[name] for name in names]
-        line.collimators.install(names, elements, need_apertures=need_apertures)
+        line.xcoll.collimators.install(names, elements, need_apertures=need_apertures)
 
     def install_geant4_collimators(self, line, *, names=None, families=None, apertures=None,
                                 need_apertures=True, s_tol=1e-6, verbose=False):
@@ -602,7 +602,7 @@ class CollimatorDatabase:
             else:
                 at.append(s_center - 0.5*getattr(self, 'length')[name])
             elements.append(self._elements[name])
-        line.collimators.install(names, elements, at=at, apertures=apertures,
+        line.xcoll.collimators.install(names, elements, at=at, apertures=apertures,
                                  need_apertures=need_apertures, s_tol=s_tol)
 
 

--- a/xcoll/environment_tools.py
+++ b/xcoll/environment_tools.py
@@ -1,0 +1,9 @@
+# copyright ############################### #
+# This file is part of the Xcoll package.   #
+# Copyright (c) CERN, 2026.                 #
+# ######################################### #
+
+
+class XcollEnvironmentAPI:
+    def __init__(self, env):
+        self._env = env

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -12,5 +12,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ======================
 # Do not change
 # ======================
-__version__ = '0.10.0rc0'
+__version__ = '0.10.0'
 # ======================

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -12,5 +12,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ======================
 # Do not change
 # ======================
-__version__ = '0.9.12'
+__version__ = '0.10.0rc0'
 # ======================

--- a/xcoll/initial_distribution.py
+++ b/xcoll/initial_distribution.py
@@ -10,8 +10,7 @@ import xtrack as xt
 import xobjects as xo
 import xpart as xp
 
-from .beam_elements import (collimator_classes, BaseCrystal, Geant4Collimator,
-                            Geant4Crystal, FlukaCollimator, FlukaCrystal)
+from .beam_elements import collimator_classes, BaseCrystal
 
 
 def generate_pencil_on_collimator(line, name, num_particles, *, side='+-', pencil_spread=1e-6,
@@ -30,12 +29,13 @@ def generate_pencil_on_collimator(line, name, num_particles, *, side='+-', penci
         raise ValueError("Need to assign optics to collimators before generating pencil distribution!")
 
     num_particles = int(num_particles)
-    if _capacity is None and len(line.get_elements_of_type(
-                                (FlukaCollimator, FlukaCrystal))[0]) > 0:
+    tt = line.get_table()
+    if _capacity is None and len(tt.rows.match(
+            element_type='FlukaCollimator|FlukaCrystal')) > 0:
         import xcoll as xc
         _capacity = cap if (cap := xc.fluka.engine.capacity) else 5*num_particles
-    if _capacity is None and len(line.get_elements_of_type(
-                                (Geant4Collimator, Geant4Crystal))[0]) > 0:
+    if _capacity is None and len(tt.rows.match(
+            element_type='Geant4Collimator|Geant4Crystal')) > 0:
         _capacity = 5*num_particles
 
     # Define the plane

--- a/xcoll/interaction_record/interaction_record.py
+++ b/xcoll/interaction_record/interaction_record.py
@@ -285,7 +285,11 @@ def _get_xcoll_elements(line=None, elements=None, names=None):
         if elements is not None and elements is not False:
             raise ValueError("Cannot provide both line and elements!")
         if names is None or names is True:
-            elements, names = line.get_elements_of_type(block_classes)
+            tt = line.get_table().rows.match(
+                element_type='|'.join(cc.__name__ for cc in block_classes)
+            )
+            names = list(tt.name)
+            elements = [line[name] for name in names]
             if len(names) == 0:
                 raise ValueError("No Xcoll elements in line!")
         elif names is False:
@@ -302,4 +306,3 @@ def _get_xcoll_elements(line=None, elements=None, names=None):
             name = name[idx] if names is not None else element.__class__.__name__
             raise ValueError(f"Element {name} not an Xcoll element!")
     return elements, names
-

--- a/xcoll/interaction_record/interaction_record.py
+++ b/xcoll/interaction_record/interaction_record.py
@@ -285,7 +285,12 @@ def _get_xcoll_elements(line=None, elements=None, names=None):
         if elements is not None and elements is not False:
             raise ValueError("Cannot provide both line and elements!")
         if names is None or names is True:
-            elements, names = line.get_elements_of_type(block_classes)
+            tt = line.get_table()
+            names = []
+            for cc in block_classes:
+                ttcc = tt.rows.match(element_type=cc.__name__)
+                names += list(ttcc.name)
+            elements = [line.get(nn) for nn in names]
             if len(names) == 0:
                 raise ValueError("No Xcoll elements in line!")
         elif names is False:
@@ -296,10 +301,9 @@ def _get_xcoll_elements(line=None, elements=None, names=None):
             for name in names:
                 if name not in line.element_names:
                     raise ValueError(f"Element {name} not found in line!")
-            elements = [line[name] for name in names]
+            elements = [line.get(nn) for nn in names]
     for idx, element in enumerate(elements):
         if not isinstance(element, block_classes):
             name = name[idx] if names is not None else element.__class__.__name__
             raise ValueError(f"Element {name} not an Xcoll element!")
     return elements, names
-

--- a/xcoll/line_tools.py
+++ b/xcoll/line_tools.py
@@ -18,6 +18,41 @@ def _iterable(obj):
     return  hasattr(obj, '__iter__') and not isinstance(obj, str)
 
 
+class XcollLineAPI:
+    def __init__(self, line):
+        self.line = line
+
+    @property
+    def scattering(self):
+        """
+        Interface to Xcoll scattering tools for this line.
+
+        Returns
+        -------
+        scattering : object
+            Xcoll scattering API bound to this line.
+        """
+        if not hasattr(self.line, '_scattering') or self.line._scattering is None:
+            self.line._scattering = XcollScatteringAPI(line=self.line)
+
+        return self.line._scattering
+
+    @property
+    def collimators(self):
+        """
+        Interface to Xcoll collimator tools for this line.
+
+        Returns
+        -------
+        collimators : object
+            Xcoll collimator API bound to this line.
+        """
+        if not hasattr(self.line, '_collimators') or self.line._collimators is None:
+            self.line._collimators = XcollCollimatorAPI(line=self.line)
+
+        return self.line._collimators
+
+
 class XcollLineAccessor:
     _typename = 'element'
 

--- a/xcoll/line_tools.py
+++ b/xcoll/line_tools.py
@@ -20,7 +20,11 @@ def _iterable(obj):
 
 class XcollLineAPI:
     def __init__(self, line):
-        self.line = line
+        self._line = line
+
+    @property
+    def line(self):
+        return self._line
 
     @property
     def scattering(self):
@@ -269,26 +273,15 @@ class XcollCollimatorAPI(XcollLineAccessor):
             warn("Warning: `at_s` is deprecated and will be removed in the "
                  "future. Please use `at` instead.", FutureWarning)
             at = at_s
-        if not _iterable(names) or not _iterable(elements) \
-        or not _iterable(at):
-            if _iterable(names):
-                raise ValueError("`names` should not be a list if any of the "
-                                 "other arguments is not a list.")
-            if _iterable(elements):
-                raise ValueError("`elements` should not be a list if any of "
-                                 "the other arguments is not a list.")
-            if _iterable(at):
-                raise ValueError("`at` should not be a list if any of the "
-                                 "other arguments is not a list.")
+        if not _iterable(names):
             names = [names]
+        if not _iterable(elements):
             elements = [elements]
+        if not _iterable(at):
             at = [at for _ in range(len(names))]
-            apertures = [apertures for _ in range(len(names))]
-        if not _iterable(apertures):
-            apertures = [apertures for _ in range(len(names))]
-        names = np.array(names)
-        length = np.array([coll.length for coll in elements])
-        if len(length) != len(names):
+        apertures = [apertures for _ in range(len(names))]  # TODO: this should be done smarter! What if we want to provide a different aperture for each element?
+        # names = np.array(names)
+        if len(elements) != len(names):
             raise ValueError("Length of `elements` does not match length of "
                              "`names`.")
         if len(at) != len(names):
@@ -297,6 +290,7 @@ class XcollCollimatorAPI(XcollLineAccessor):
         if len(apertures) != len(names):
             raise ValueError("Length of `apertures` does not match length of "
                              "`names`.")
+        length = np.array([coll.length for coll in elements])
 
         # Verify elements
         for name, el in zip(names, elements):

--- a/xcoll/line_tools.py
+++ b/xcoll/line_tools.py
@@ -121,7 +121,12 @@ class XcollScatteringAPI(XcollLineAccessor):
     def names(self):
         # This makes sure the accessor can access the names of the
         # collimators dynamically
-        return self.line.get_elements_of_type(element_classes)[1]
+        tt = self.line.get_table()
+        names = []
+        for cc in element_classes:
+            ttcc = tt.rows.match(element_type=cc.__name__)
+            names += list(ttcc.name)
+        return names
 
     def enable(self):
         if len(self) == 0:
@@ -168,7 +173,12 @@ class XcollCollimatorAPI(XcollLineAccessor):
     def names(self):
         # This makes sure the accessor can access the names of the
         # collimators dynamically
-        return self.line.get_elements_of_type(collimator_classes)[1]
+        tt = self.line.get_table()
+        names = []
+        for cc in collimator_classes:
+            ttcc = tt.rows.match(element_type=cc.__name__)
+            names += list(ttcc.name)
+        return names
 
     @property
     def families(self):
@@ -483,7 +493,12 @@ class XcollCollimatorAPI(XcollLineAccessor):
                                twiss_downstream=tw_downstream, beta_gamma_rel=beta_gamma_rel)
 
     def align_to_beam_divergence(self):
-        crystals = self.line.get_elements_of_type(crystal_classes)[0]
+        tt = self.line.get_table()
+        crystal_names = []
+        for cc in crystal_classes:
+            ttcc = tt.rows.match(element_type=cc.__name__)
+            crystal_names += list(ttcc.name)
+        crystals = [self.line.get(nn) for nn in crystal_names]
         if len(crystals) == 0:
             warn("No crystals found in line to align to beam divergence.")
         for el in crystals:

--- a/xcoll/line_tools.py
+++ b/xcoll/line_tools.py
@@ -121,7 +121,10 @@ class XcollScatteringAPI(XcollLineAccessor):
     def names(self):
         # This makes sure the accessor can access the names of the
         # collimators dynamically
-        return self.line.get_elements_of_type(element_classes)[1]
+        tt = self.line.get_table().rows.match(
+            element_type='|'.join(cc.__name__ for cc in element_classes)
+        )
+        return list(tt.name)
 
     def enable(self):
         if len(self) == 0:
@@ -168,7 +171,10 @@ class XcollCollimatorAPI(XcollLineAccessor):
     def names(self):
         # This makes sure the accessor can access the names of the
         # collimators dynamically
-        return self.line.get_elements_of_type(collimator_classes)[1]
+        tt = self.line.get_table().rows.match(
+            element_type='|'.join(cc.__name__ for cc in collimator_classes)
+        )
+        return list(tt.name)
 
     @property
     def families(self):
@@ -483,7 +489,10 @@ class XcollCollimatorAPI(XcollLineAccessor):
                                twiss_downstream=tw_downstream, beta_gamma_rel=beta_gamma_rel)
 
     def align_to_beam_divergence(self):
-        crystals = self.line.get_elements_of_type(crystal_classes)[0]
+        tt = self.line.get_table().rows.match(
+            element_type='|'.join(cc.__name__ for cc in crystal_classes)
+        )
+        crystals = [self.line[name] for name in tt.name]
         if len(crystals) == 0:
             warn("No crystals found in line to align to beam divergence.")
         for el in crystals:

--- a/xcoll/lossmap.py
+++ b/xcoll/lossmap.py
@@ -12,9 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 import xtrack as xt
 import xtrack.particles.pdg as pdg
 
-from .beam_elements import (collimator_classes, crystal_classes,
-                            FlukaCollimator, FlukaCrystal,
-                            Geant4Collimator, Geant4Crystal)
+from .beam_elements import collimator_classes, crystal_classes
 from .compare import deep_equal
 from .json import json_load, json_dump
 from .general import __version__
@@ -384,10 +382,13 @@ class LossMap:
         collimator summary is updated.
         """
         # Check that collimators have been tracked
-        geant4_coll = line.get_elements_of_type((Geant4Collimator, Geant4Crystal))[0]
+        tt = line.get_table()
+        tt_geant4 = tt.rows.match(element_type='Geant4Collimator|Geant4Crystal')
+        geant4_coll = [line[name] for name in tt_geant4.name]
         if len(geant4_coll) > 0 and np.all([coll._acc_ionisation_loss < 0 for coll in geant4_coll]):
             raise ValueError("Geant4Collimators have not been tracked, or LossMap already calculated")
-        fluka_coll = line.get_elements_of_type((FlukaCollimator, FlukaCrystal))[0]
+        tt_fluka = tt.rows.match(element_type='FlukaCollimator|FlukaCrystal')
+        fluka_coll = [line[name] for name in tt_fluka.name]
         if len(fluka_coll) > 0 and np.all([coll._acc_ionisation_loss < 0 for coll in fluka_coll]):
             raise ValueError("FlukaCollimators have not been tracked, or LossMap already calculated")
         if interpolation is not None:
@@ -399,7 +400,10 @@ class LossMap:
             self.interpolation = 0.1 # Default
         if not isinstance(correct_aperture_absorption, dict):
             coll_classes = list(set(collimator_classes) - set(crystal_classes))
-            coll_elements = line.get_elements_of_type(coll_classes)[1]
+            tt_colls = tt.rows.match(
+                element_type='|'.join(cc.__name__ for cc in coll_classes)
+            )
+            coll_elements = list(tt_colls.name)
             correct_aperture_absorption = {coll: correct_aperture_absorption
                                             for coll in coll_elements}
         for coll, this_aper_corr in correct_aperture_absorption.items():
@@ -610,14 +614,18 @@ class LossMap:
 
 
     def _make_coll_summary(self, part, line, line_shift_s, weights):
-        names = np.unique(line.get_elements_of_type(collimator_classes)[1])
+        tt = line.get_table()
+        tt_colls = tt.rows.match(
+            element_type='|'.join(cc.__name__ for cc in collimator_classes)
+        )
+        names = np.unique(tt_colls.name)
         coll_mask = np.isin(part.state, USE_IN_LOSSMAP)
         coll_losses = np.array([line.element_names[i]
                                 for i in part.at_element[coll_mask]])
         coll_lengths = [line[name].length for name in names]
 
         L = self.machine_length
-        coll_pos = np.array([(line.get_s_position(name) + cl/2 + line_shift_s)%L
+        coll_pos = np.array([(tt['s', name] + cl/2 + line_shift_s)%L
                     for name, cl in zip(names, coll_lengths)])
         if self.line_is_reversed:
             coll_pos = L - coll_pos

--- a/xcoll/lossmap.py
+++ b/xcoll/lossmap.py
@@ -12,9 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 import xtrack as xt
 import xtrack.particles.pdg as pdg
 
-from .beam_elements import (collimator_classes, crystal_classes,
-                            FlukaCollimator, FlukaCrystal,
-                            Geant4Collimator, Geant4Crystal)
+from .beam_elements import collimator_classes, crystal_classes
 from .compare import deep_equal
 from .json import json_load, json_dump
 from .general import __version__
@@ -384,10 +382,13 @@ class LossMap:
         collimator summary is updated.
         """
         # Check that collimators have been tracked
-        geant4_coll = line.get_elements_of_type((Geant4Collimator, Geant4Crystal))[0]
+        tt = line.get_table()
+        tt_geant4 = tt.rows.match(element_type='Geant4Collimator|Geant4Crystal')
+        geant4_coll = [line.get(nn) for nn in tt_geant4.name]
         if len(geant4_coll) > 0 and np.all([coll._acc_ionisation_loss < 0 for coll in geant4_coll]):
             raise ValueError("Geant4Collimators have not been tracked, or LossMap already calculated")
-        fluka_coll = line.get_elements_of_type((FlukaCollimator, FlukaCrystal))[0]
+        tt_fluka = tt.rows.match(element_type='FlukaCollimator|FlukaCrystal')
+        fluka_coll = [line.get(nn) for nn in tt_fluka.name]
         if len(fluka_coll) > 0 and np.all([coll._acc_ionisation_loss < 0 for coll in fluka_coll]):
             raise ValueError("FlukaCollimators have not been tracked, or LossMap already calculated")
         if interpolation is not None:
@@ -399,7 +400,10 @@ class LossMap:
             self.interpolation = 0.1 # Default
         if not isinstance(correct_aperture_absorption, dict):
             coll_classes = list(set(collimator_classes) - set(crystal_classes))
-            coll_elements = line.get_elements_of_type(coll_classes)[1]
+            coll_elements = []
+            for cc in coll_classes:
+                ttcc = tt.rows.match(element_type=cc.__name__)
+                coll_elements += list(ttcc.name)
             correct_aperture_absorption = {coll: correct_aperture_absorption
                                             for coll in coll_elements}
         for coll, this_aper_corr in correct_aperture_absorption.items():
@@ -610,14 +614,19 @@ class LossMap:
 
 
     def _make_coll_summary(self, part, line, line_shift_s, weights):
-        names = np.unique(line.get_elements_of_type(collimator_classes)[1])
+        tt = line.get_table()
+        coll_names = []
+        for cc in collimator_classes:
+            ttcc = tt.rows.match(element_type=cc.__name__)
+            coll_names += list(ttcc.name)
+        names = np.unique(coll_names)
         coll_mask = np.isin(part.state, USE_IN_LOSSMAP)
         coll_losses = np.array([line.element_names[i]
                                 for i in part.at_element[coll_mask]])
         coll_lengths = [line[name].length for name in names]
 
         L = self.machine_length
-        coll_pos = np.array([(line.get_s_position(name) + cl/2 + line_shift_s)%L
+        coll_pos = np.array([(tt['s', name] + cl/2 + line_shift_s)%L
                     for name, cl in zip(names, coll_lengths)])
         if self.line_is_reversed:
             coll_pos = L - coll_pos

--- a/xcoll/rf_sweep.py
+++ b/xcoll/rf_sweep.py
@@ -58,7 +58,7 @@ class RFSweep:
             self._install_zeta_shift()
             self.tw = self.line.twiss()
             self.reset() # Initialize rf_sweep_df
-            self.env['rf_sweep'].dzeta = f"{self.L} * rf_sweep_df / ({self.f_RF} + rf_sweep_df)"
+            self.env['rf_sweep'].shift_zeta = f"{self.L} * rf_sweep_df / ({self.f_RF} + rf_sweep_df)"
             for cavs in self.cavities:
                 for cav in cavs['names']:
                     scale_factor = int(np.round(cavs['freq'] / self.f_RF))
@@ -74,7 +74,7 @@ class RFSweep:
     def reset(self):
         if self.sweep_per_turn is None:
             raise ValueError("RFSweep not prepared. Call `prepare` first.")
-        t_turn = self.tw.T_rev0   # To start sweeping from turn 0
+        t_turn = self.tw.t_rev0   # To start sweeping from turn 0
         current_time = self.env['t_turn_s']
         if current_time == 0:
             self.env['rf_sweep_df'] = f"(t_turn_s + {t_turn}) / {t_turn} * {self.sweep_per_turn}"
@@ -164,7 +164,8 @@ class RFSweep:
         self._resolve_cavity_frequency()
         freq = np.array([self.env[cav].frequency for cav in self.cavities])
         volt = np.array([self.env[cav].voltage for cav in self.cavities])
-        lag  = np.array([self.env[cav].lag for cav in self.cavities])
+        phase = np.array([self.env[cav].phase + np.deg2rad(self.env[cav].lag)
+                          for cav in self.cavities])
         s_pos = []
         name_first_in_line = []
         for cav in self.cavities:
@@ -187,14 +188,14 @@ class RFSweep:
                 'freq': np.mean(freq[gidx]),
                 'voltage': volt[gidx].sum(),
                 's_pos': np.array(s_pos)[gidx],
-                'lag': lag[gidx],
+                'phase': phase[gidx],
                 'name_first_in_line': np.array(name_first_in_line)[gidx],
             })
         self.cavities = sorted(groups, key=lambda g: (g['voltage'], g['freq']), reverse=True)
         if np.isclose(self.cavities[0]['voltage'], 0):
             raise ValueError("No active cavity found!")
         self.f_RF = self.cavities[0]['freq']
-        self.phi = np.deg2rad(self.cavities[0]['lag'].mean())
+        self.phi = self.cavities[0]['phase'].mean()
         self.V = self.cavities[0]['voltage']
         self.L = self.line.get_length()
         if len(self.cavities) > 1:
@@ -210,5 +211,5 @@ class RFSweep:
         if 'rf_sweep' not in self.env.elements:
             idx = np.argsort(self.cavities[0]['s_pos'])
             first_cavity = self.cavities[0]['name_first_in_line'][idx[0]]
-            self.env.elements['rf_sweep'] = xt.ZetaShift(dzeta=0)
+            self.env.elements['rf_sweep'] = xt.TimeDelay(shift_zeta=0)
             self.line.insert('rf_sweep', at=f'{first_cavity}@start')

--- a/xcoll/scattering_routines/engine.py
+++ b/xcoll/scattering_routines/engine.py
@@ -666,14 +666,12 @@ class BaseEngine(xo.HybridClass):
                 self.stop()
                 raise ValueError("Cannot provide both `line` and `elements`.")
             if names is None:
-                elements, names = self.line.get_elements_of_type(self._element_classes)
-                # This method can return duplicate elements if there are subclasses (like Geant4Collimator
-                # and Geant4CollimatorTip) as elements of the child type will also be found by searching
-                # for the parent type.
-                d = {}
-                for nn, ee in zip(names, elements):
-                    d[nn] = ee # last one wins, not important here
-                names, elements = list(d.keys()), list(d.values())
+                tt = self.line.get_table().rows.match(
+                    element_type='|'.join(cc.__name__
+                                          for cc in self._element_classes)
+                )
+                names = list(tt.name)
+                elements = [self.line[name] for name in names]
             else:
                 elements = [self.line[name] for name in names]
         this_names = []

--- a/xcoll/scattering_routines/engine.py
+++ b/xcoll/scattering_routines/engine.py
@@ -666,16 +666,14 @@ class BaseEngine(xo.HybridClass):
                 self.stop()
                 raise ValueError("Cannot provide both `line` and `elements`.")
             if names is None:
-                elements, names = self.line.get_elements_of_type(self._element_classes)
-                # This method can return duplicate elements if there are subclasses (like Geant4Collimator
-                # and Geant4CollimatorTip) as elements of the child type will also be found by searching
-                # for the parent type.
-                d = {}
-                for nn, ee in zip(names, elements):
-                    d[nn] = ee # last one wins, not important here
-                names, elements = list(d.keys()), list(d.values())
+                tt = self.line.get_table()
+                names = []
+                for cc in self._element_classes:
+                    ttcc = tt.rows.match(element_type=cc.__name__)
+                    names += list(ttcc.name)
+                elements = [self.line.get(nn) for nn in names]
             else:
-                elements = [self.line[name] for name in names]
+                elements = [self.line.get(nn) for nn in names]
         this_names = []
         this_elements = []
         for ee, name in zip(elements, names):


### PR DESCRIPTION
- **Adapt tests to use line tables**
- **Adapt examples to use line tables**
- **Use line tables for element type queries**
- **Use line tables for element type queries**
- **Adapt xcoll to Line.xcoll facade**
- **Remove deprecated API use in xcoll**
- **Adapt json (by hand)**
- **Adapt json (by hand)**
- **Adapt json (by hand)**
- **Adapt json (by hand)**
- **Add xcoll-owned line API facade**
- **Add environment API facade**
- **Created release branch release/v0.10.0rc0.**
- **Fix in line tools**
- **Updated version number to v0.10.0.**
