### PR TITLE
Release 0.11.6

### DIFF
--- a/examples/fluka_init.py
+++ b/examples/fluka_init.py
@@ -5,17 +5,17 @@ from pathlib import Path
 path = Path('/Users/frederik/ExternalLibs')
 
 # Set the paths to FLUKA executables
-xc.fluka.environment.fluka	 = path / 'fluka4-5.1' / 'bin' / 'rfluka'
-xc.fluka.environment.flukaserver = path / 'fluka4-5.1' / 'bin' / 'flukaserver'
-xc.fluka.environment.linebuilder = path / 'linebuilder'
-xc.fluka.environment.flair       = path / 'flair-3.4' / 'flair'
+xc.fluka.interface.fluka	 = path / 'fluka4-5.1' / 'bin' / 'rfluka'
+xc.fluka.interface.flukaserver = path / 'fluka4-5.1' / 'bin' / 'flukaserver'
+xc.fluka.interface.linebuilder = path / 'linebuilder'
+xc.fluka.interface.flair       = path / 'flair-3.4' / 'flair'
 
-print(xc.fluka.environment)
+print(xc.fluka.interface)
 print()
 
 # Compile the FLUKA interface. This should be done within the environment it will be used to avoid dependency issues.
 # E.g. when running on HTCondor with cvmfs, compile with cvmfs sourced.
-xc.fluka.environment.compile(flukaio_lib=path / 'fluka4-5.1' / 'lib' / 'libFlukaIO.a', verbose=True)
+xc.fluka.interface.compile(flukaio_lib=path / 'fluka4-5.1' / 'lib' / 'libFlukaIO.a', verbose=True)
 
 # Import a FLUKA FEDB
-xc.fluka.environment.import_fedb(fedb_path=path / 'fedb_coupling', verbose=True, overwrite=False)
+xc.fluka.interface.import_fedb(fedb_path=path / 'fedb_coupling', verbose=True, overwrite=False)

--- a/examples/fluka_init_eos.py
+++ b/examples/fluka_init_eos.py
@@ -3,17 +3,17 @@ import xcoll as xc
 from pathlib import Path
 
 # Set the paths to FLUKA executables
-xc.fluka.environment.fluka       = '/eos/project/f/flukafiles/fluka-coupling/fluka4-5.0/bin/rfluka'
-xc.fluka.environment.flukaserver = '/eos/project/f/flukafiles/fluka-coupling/fluka_coupling/fluka/flukaserver'
-xc.fluka.environment.linebuilder = '/eos/project/c/collimation-team/software/fluka_coupling_tmp_patch_xsuite'
-xc.fluka.environment.flair       = '/eos/project/f/flukafiles/fluka-coupling/flair-3.4/flair'
+xc.fluka.interface.fluka       = '/eos/project/f/flukafiles/fluka-coupling/fluka4-5.0/bin/rfluka'
+xc.fluka.interface.flukaserver = '/eos/project/f/flukafiles/fluka-coupling/fluka_coupling/fluka/flukaserver'
+xc.fluka.interface.linebuilder = '/eos/project/c/collimation-team/software/fluka_coupling_tmp_patch_xsuite'
+xc.fluka.interface.flair       = '/eos/project/f/flukafiles/fluka-coupling/flair-3.4/flair'
 
-print(xc.fluka.environment)
+print(xc.fluka.interface)
 print()
 
 # Compile the FLUKA interface. This should be done within the environment it will be used to avoid dependency issues.
 # E.g. when running on HTCondor with cvmfs, compile with cvmfs sourced.
-xc.fluka.environment.compile(flukaio_path='/eos/project-c/collimation-team/software/flukaio', verbose=True)
+xc.fluka.interface.compile(flukaio_path='/eos/project-c/collimation-team/software/flukaio', verbose=True)
 
 # Import a FLUKA FEDB
-xc.fluka.environment.import_fedb(fedb_path='/eos/project/c/collimation-team/software/fedb_coupling', verbose=True, overwrite=False)
+xc.fluka.interface.import_fedb(fedb_path='/eos/project/c/collimation-team/software/fedb_coupling', verbose=True, overwrite=False)

--- a/examples/geant4_init.py
+++ b/examples/geant4_init.py
@@ -1,6 +1,6 @@
 # This script needs to be ran only once, to set the Geant4 environment.
 import xcoll as xc
 
-print(xc.geant4.environment)
+print(xc.geant4.interface)
 print()
-xc.geant4.environment.compile(verbose=True, verbose_compile_output=True)
+xc.geant4.interface.compile(verbose=True, verbose_compile_output=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xcoll"
-version = "0.11.5"
+version = "0.11.6rc0"
 description = "Xsuite collimation package"
 authors = [
     {name="Frederik F. Van der Veken", email="frederik@cern.ch"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xcoll"
-version = "0.11.6rc0"
+version = "0.11.6"
 description = "Xsuite collimation package"
 authors = [
     {name="Frederik F. Van der Veken", email="frederik@cern.ch"},
@@ -22,10 +22,10 @@ dependencies = [
     "ruamel-yaml>=0.17.31",
     "numpy>=1.0",
     "pandas>=1.4",
-    "xobjects>=0.6.5",
+    "xobjects>=0.6.6",
     "xdeps>=0.10.19",
     "xpart>=0.23.16",
-    "xtrack>=0.107.9",
+    "xtrack>=0.108.0",
     "meson"
 ]
 

--- a/tests/_common_api.py
+++ b/tests/_common_api.py
@@ -10,8 +10,8 @@ except ImportError as e:
     rpyc = None
 import xcoll as xc
 
-if xc.geant4.environment.ready:
-    old_bdsim = xc.geant4.environment.bdsim_older_than(compare_version='1.7.7.develop')  # No unstable particles returned in older BDSIM
+if xc.geant4.interface.ready:
+    old_bdsim = xc.geant4.interface.bdsim_older_than(compare_version='1.7.7.develop')  # No unstable particles returned in older BDSIM
 else:
     old_bdsim = True
 
@@ -28,10 +28,10 @@ all_engine_params = [
 
 def check_skip(engine):
     if engine == "fluka":
-        if not xc.fluka.environment.ready:
+        if not xc.fluka.interface.ready:
             pytest.skip("FLUKA installation not found")
     elif engine == "geant4":
-        if not xc.geant4.environment.ready:
+        if not xc.geant4.interface.ready:
             pytest.skip("BDSIM+Geant4 installation not found")
         if rpyc is None:
             pytest.skip("rpyc not installed")

--- a/tests/test_fluka.py
+++ b/tests/test_fluka.py
@@ -12,7 +12,7 @@ import xpart as xp
 import xtrack as xt
 import xcoll as xc
 
-from xcoll.scattering_routines.fluka.interface import format_fluka_float
+from xcoll.scattering_routines.fluka.environment import format_fluka_float
 
 
 @pytest.mark.fluka

--- a/tests/test_fluka.py
+++ b/tests/test_fluka.py
@@ -12,7 +12,7 @@ import xpart as xp
 import xtrack as xt
 import xcoll as xc
 
-from xcoll.scattering_routines.fluka.environment import format_fluka_float
+from xcoll.scattering_routines.fluka.interface import format_fluka_float
 
 
 @pytest.mark.fluka

--- a/tests/test_fluka_assemblies.py
+++ b/tests/test_fluka_assemblies.py
@@ -12,7 +12,7 @@ import xcoll as xc
 @pytest.mark.serial
 @pytest.mark.fluka
 def test_registry_initialisation():
-    xc.fluka.environment # Force initialization
+    xc.fluka.interface # Force initialization
     assert xc.FlukaPrototype._registry is xc.FlukaAssembly._registry
     assert len(xc.FlukaPrototype._registry) >= 7 # Has at least Maria crystals and Donadon test assembly
     assert len([pro for pro in xc.FlukaPrototype._registry if isinstance(pro, xc.FlukaAssembly)]) >= 1
@@ -22,7 +22,7 @@ def test_registry_initialisation():
 @pytest.mark.serial
 @pytest.mark.fluka
 def test_new_null():
-    xc.fluka.environment # Force initialization
+    xc.fluka.interface # Force initialization
     new_pro = xc.FlukaPrototype()
     assert new_pro._is_null
     assert new_pro not in xc.FlukaPrototype._registry
@@ -34,7 +34,7 @@ def test_new_null():
 @pytest.mark.serial
 @pytest.mark.fluka
 def test_new_prototype():
-    xc.fluka.environment # Force initialization
+    xc.fluka.interface # Force initialization
     prototypes_before = xc.FlukaPrototype._registry.copy()
     with pytest.raises(ValueError, match="Both 'fedb_series' and 'fedb_tag' must be provided."):
         new_pro = xc.FlukaPrototype(fedb_series='test')
@@ -169,7 +169,7 @@ def test_prototype_with_files():
 @pytest.mark.serial
 @pytest.mark.fluka
 def test_new_assembly():
-    xc.fluka.environment # Force initialization
+    xc.fluka.interface # Force initialization
     assemblies_before = xc.FlukaAssembly._registry.copy()
     with pytest.raises(ValueError, match="Both 'fedb_series' and 'fedb_tag' must be provided."):
         new_assm = xc.FlukaAssembly(fedb_series='test')
@@ -209,7 +209,7 @@ def test_new_assembly():
 @pytest.mark.serial
 @pytest.mark.fluka
 def test_assembly_with_files():
-    xc.fluka.environment # Force initialization
+    xc.fluka.interface # Force initialization
     # Create prototypes needed for the assembly
     new_pro_jaw = xc.FlukaPrototype(fedb_series='test', fedb_tag='PROTO_B')
     with open("pro_body.txt", "w") as f:

--- a/tests/test_geant4_serial_bdsim.py
+++ b/tests/test_geant4_serial_bdsim.py
@@ -18,7 +18,7 @@ particle_ref = xt.Particles('proton', p0c=6.8e12)
 
 @pytest.mark.serial
 @pytest.mark.geant4
-@pytest.mark.skipif(not xc.geant4.environment.ready, reason="BDSIM+Geant4 installation not found")
+@pytest.mark.skipif(not xc.geant4.interface.ready, reason="BDSIM+Geant4 installation not found")
 def test_serial_bdsim():
     # Skip if Geant4Engine has already been started
     if xc.geant4.engine._already_started:

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,4 +9,4 @@ from xcoll import __version__
 
 @pytest.mark.xcother
 def test_version():
-    assert __version__ == '0.11.6rc0'
+    assert __version__ == '0.11.6'

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,4 +9,4 @@ from xcoll import __version__
 
 @pytest.mark.xcother
 def test_version():
-    assert __version__ == '0.11.5'
+    assert __version__ == '0.11.6rc0'

--- a/xcoll/__init__.py
+++ b/xcoll/__init__.py
@@ -23,6 +23,10 @@ from .environment_tools import XcollEnvironmentAPI
 
 from .constants import particle_states, particle_state_names, interactions, interaction_names
 
+# Initialise the Xcoll environment
+from .package_env import BaseInterface
+interface = BaseInterface()
+
 # Initialise FLUKA environment
 from .scattering_routines.fluka.wrapper import FlukaWrapper as _FlukaWrapper
 fluka = _FlukaWrapper()

--- a/xcoll/_xobjects.py
+++ b/xcoll/_xobjects.py
@@ -3,13 +3,18 @@
 # Copyright (c) CERN, 2026.                 #
 # ######################################### #
 
-from .general import _pkg_root
+import xcoll as xc
 
 
 # Declare paths and libraries to xobjects
 def get_build_info():
+    libraries = set()
+    library_dirs = set()
+    if xc.fluka.environment.ready:
+        libraries.add("FlukaIO")
+        library_dirs.add(xc.fluka.environment.lib_dir)
     return {
-        "include_dirs": [_pkg_root.parent],
-        "libraries": ["FlukaIO"],
-        "library_dirs": [_pkg_root / "lib"],
+        "include_dirs": [xc._pkg_root.parent],
+        "libraries": list(libraries),
+        "library_dirs": list(library_dirs),
     }

--- a/xcoll/_xobjects.py
+++ b/xcoll/_xobjects.py
@@ -10,9 +10,9 @@ import xcoll as xc
 def get_build_info():
     libraries = set()
     library_dirs = set()
-    if xc.fluka.environment.ready:
+    if xc.fluka.interface.ready:
         libraries.add("FlukaIO")
-        library_dirs.add(xc.fluka.environment.lib_dir)
+        library_dirs.add(xc.fluka.interface.lib_dir)
     return {
         "include_dirs": [xc._pkg_root.parent],
         "libraries": list(libraries),

--- a/xcoll/beam_elements/fluka.py
+++ b/xcoll/beam_elements/fluka.py
@@ -241,7 +241,7 @@ class FlukaCollimator(BaseCollimator):
 
     def enable_scattering(self):
         import xcoll as xc
-        xc.fluka.environment.assert_environment_ready()
+        xc.fluka.interface.assert_environment_ready()
         if not xc.fluka.engine.is_running():
             raise RuntimeError("FLUKA engine is not running.")
         super().enable_scattering()
@@ -541,7 +541,7 @@ class FlukaCrystal(BaseCrystal):
 
     def enable_scattering(self):
         import xcoll as xc
-        xc.fluka.environment.assert_environment_ready()
+        xc.fluka.interface.assert_environment_ready()
         if not xc.fluka.engine.is_running():
             raise RuntimeError("FLUKA engine is not running.")
         super().enable_scattering()

--- a/xcoll/beam_elements/geant4.py
+++ b/xcoll/beam_elements/geant4.py
@@ -91,7 +91,7 @@ class Geant4Collimator(BaseCollimator):
 
     def enable_scattering(self):
         import xcoll as xc
-        xc.geant4.environment.assert_environment_ready()
+        xc.geant4.interface.assert_environment_ready()
         if not xc.geant4.engine.is_running():
             raise RuntimeError("Geant4 engine is not running.")
         super().enable_scattering()

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -3,9 +3,12 @@
 # Copyright (c) CERN, 2025.                 #
 # ######################################### #
 
-from pathlib import Path
+try:
+    from xaux import FsPath  # TODO: once xaux is in Xsuite keep only this
+except (ImportError, ModuleNotFoundError):
+    from .xaux import FsPath
 
-_pkg_root = Path(__file__).parent.absolute()
+_pkg_root = FsPath(__file__).parent.absolute()
 
 citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools for Collimation Simulations in Xsuite, Proceedings of HB2023, Geneva, Switzerland."
 

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -12,5 +12,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ======================
 # Do not change
 # ======================
-__version__ = '0.11.5'
+__version__ = '0.11.6rc0'
 # ======================

--- a/xcoll/general.py
+++ b/xcoll/general.py
@@ -15,5 +15,5 @@ citation = "F.F. Van der Veken, et al.: Recent Developments with the New Tools f
 # ======================
 # Do not change
 # ======================
-__version__ = '0.11.6rc0'
+__version__ = '0.11.6'
 # ======================

--- a/xcoll/package_env.py
+++ b/xcoll/package_env.py
@@ -82,7 +82,7 @@ _data_dir = _select_directory('data')
 _lib_dir = _select_directory('lib')
 
 
-class BaseEnvironment:
+class BaseInterface:
     _config_dir = _config_dir
     _data_dir = _data_dir
     _lib_dir = _lib_dir
@@ -116,14 +116,14 @@ class BaseEnvironment:
         return f"<{self.__class__.__name__} at {hex(id(self))} (use .show() to see the paths)>"
 
     def __str__(self):
-        res = ["XcollEnvironment"]
+        res = ["BaseInterface"]
         res.append(f"    Configuration file:  {self._config_file.as_posix()}")
         res.append(f"    Configuration dir:   {self._config_dir.as_posix()}")
         res.append(f"    Library dir:         {self._lib_dir.as_posix()}")
         res.append(f"    Data dir:            {self._data_dir.as_posix()}")
         if self._temp_dir:
             res.append(f"    Temporary dir:       {self._temp_dir.name}")
-        if self.__class__ is not BaseEnvironment:
+        if self.__class__ is not BaseInterface:
             res.append("")
             res.append(f"{self.__class__.__name__}")
             for path in self._paths.keys():
@@ -156,7 +156,7 @@ class BaseEnvironment:
 
     @property
     def config_file(self):
-        """The environment configuration file."""
+        """The interface configuration file."""
         return self._config_file
 
     @property
@@ -218,7 +218,7 @@ class BaseEnvironment:
         self.temp_dir = None
 
     def show(self):
-        """Print the environment paths."""
+        """Print the interface paths."""
         print(self)
 
     def save(self):
@@ -350,7 +350,7 @@ class BaseEnvironment:
     def assert_environment_ready(self):
         if not self.initialised:
             raise RuntimeError(f"{self.__class__.__name__} not initialised! "
-                            f"Please set all paths in the environment before "
+                            f"Please set all paths in the interface before "
                             f"starting the engine.")
         if not self.compiled:
             raise RuntimeError(f"{self.__class__.__name__} not compiled! "

--- a/xcoll/package_env.py
+++ b/xcoll/package_env.py
@@ -102,7 +102,7 @@ class BaseInterface:
         self._config_dir.mkdir(parents=True, exist_ok=True)
         self._data_dir.mkdir(parents=True, exist_ok=True)
         self._lib_dir.mkdir(parents=True, exist_ok=True)
-        self._config_file = self._config_dir / f'{self.__class__.__name__[:-11].lower()}.config.json'
+        self._config_file = self._config_dir / f'{self.__class__.__name__[:-9].lower()}.config.json'
         sys.path.append(self._lib_dir.as_posix())
         self.load()
         self._in_constructor = False

--- a/xcoll/package_env.py
+++ b/xcoll/package_env.py
@@ -7,53 +7,85 @@ import os
 import sys
 import json
 import tempfile
-import getpass
 from subprocess import run, PIPE
-# from platformdirs import user_config_dir, user_data_dir
+# try:
+#     from platformdirs import user_config_path, user_data_path
+# except (ImportError, ModuleNotFoundError):
+#     user_config_path = None
+#     user_data_path = None
 
-from ..general import _pkg_root
-from pathlib import Path
+from .general import _pkg_root
+
 try:
     from xaux import FsPath  # TODO: once xaux is in Xsuite keep only this
 except (ImportError, ModuleNotFoundError):
-    from ..xaux import FsPath
+    from .xaux import FsPath
 
-def _is_writable_directory(path: str | Path) -> bool:
-    directory = Path(path).expanduser()
 
-    if not directory.is_dir():
-        return False
+# Xcoll paths can be set via environment variables:
+#   XCOLL_PATH: parent directory for all Xcoll paths (config, data, lib)
+#   XCOLL_CONFIG_PATH: directory for configuration files
+#   XCOLL_DATA_PATH: directory for data files
+#   XCOLL_LIB_PATH: directory for library files
+#
+# Otherwise the paths are set in the home folder (~/.xcoll/), the package
+# folder (xcoll/xcoll/), or, if those are not writable, in a temporary
+# folder (/tmp/xcoll/).
 
+
+def _is_writable_directory(path: FsPath) -> bool:
+    newly_generated = False
+    if path.exists():
+        if not path.is_dir():
+            return False
+    else:
+        try:
+            path.mkdir(parents=True, exist_ok=True)
+            newly_generated = True
+        except OSError:
+            return False
     try:
-        with tempfile.TemporaryFile(dir=directory):
+        with tempfile.TemporaryFile(dir=path):
             pass
-        return True
     except OSError:
+        if newly_generated:
+            try:
+                path.rmdir()
+            except OSError:
+                pass
         return False
+    return True
 
-def _select_directory_for_config_and_data(preferred: str | Path) -> Path:
-    candidates = [
-        Path(preferred).expanduser(),
-        Path.home(),
-        Path(tempfile.gettempdir()),
+def _select_directory(name) -> FsPath:
+    candidates = []
+    env_var_name = f'XCOLL_{name.upper()}_PATH'
+    env_var = os.environ.get(env_var_name)
+    if env_var is not None:
+        candidates.append(FsPath(env_var).expanduser().resolve())
+    env_var_parent = os.environ.get('XCOLL_PATH')
+    if env_var_parent is not None:
+        candidates.append(
+            (FsPath(env_var_parent) / name).expanduser().resolve()
+        )
+    candidates += [
+        FsPath.home() / '.xcoll' / name,
+        _pkg_root / name,
+        FsPath(tempfile.gettempdir()) / 'xcoll' / name,
     ]
-    # Prefer persistent directory, if nothing available, use /tmp
-    for directory in candidates:
-        if _is_writable_directory(directory):
-            if directory == Path(tempfile.gettempdir()):
-                return directory.joinpath(getpass.getuser())
-            else:
-                return directory
-
+    for path in candidates:
+        if _is_writable_directory(path):
+            return path
     raise RuntimeError("No writable directory was found.")
 
-_config_and_data_root = _select_directory_for_config_and_data(_pkg_root).joinpath(".xcoll")
+_config_dir = _select_directory('config')
+_data_dir = _select_directory('data')
+_lib_dir = _select_directory('lib')
+
 
 class BaseEnvironment:
-    _config_dir = FsPath(_config_and_data_root / 'config').resolve()
-    _data_dir   = FsPath(_config_and_data_root / 'lib').resolve()
-    # _config_dir = FsPath(user_config_dir('xcoll')).resolve()
-    # _data_dir   = FsPath(user_data_dir('xcoll')).resolve()
+    _config_dir = _config_dir
+    _data_dir = _data_dir
+    _lib_dir = _lib_dir
     _paths = {} # The value is the parent depth that needs to be brute-forced (0 = file itself, None = no brute-force)
     _optional_paths = {}
     _read_only_paths = {}
@@ -69,8 +101,9 @@ class BaseEnvironment:
             setattr(self, f'_{path}', None)
         self._config_dir.mkdir(parents=True, exist_ok=True)
         self._data_dir.mkdir(parents=True, exist_ok=True)
+        self._lib_dir.mkdir(parents=True, exist_ok=True)
         self._config_file = self._config_dir / f'{self.__class__.__name__[:-11].lower()}.config.json'
-        sys.path.append(self._data_dir.as_posix())
+        sys.path.append(self._lib_dir.as_posix())
         self.load()
         self._in_constructor = False
 
@@ -86,6 +119,7 @@ class BaseEnvironment:
         res = ["XcollEnvironment"]
         res.append(f"    Configuration file:  {self._config_file.as_posix()}")
         res.append(f"    Configuration dir:   {self._config_dir.as_posix()}")
+        res.append(f"    Library dir:         {self._lib_dir.as_posix()}")
         res.append(f"    Data dir:            {self._data_dir.as_posix()}")
         if self._temp_dir:
             res.append(f"    Temporary dir:       {self._temp_dir.name}")
@@ -134,6 +168,11 @@ class BaseEnvironment:
     def data_dir(self):
         """The directory where the data files are stored."""
         return self._data_dir
+
+    @property
+    def lib_dir(self):
+        """The directory where the library files are stored."""
+        return self._lib_dir
 
     @property
     def initialised(self):

--- a/xcoll/prebuilt_kernel_definitions/element_types.py
+++ b/xcoll/prebuilt_kernel_definitions/element_types.py
@@ -21,9 +21,9 @@ DEFAULT_XCOLL_ELEMENTS = [
 
 XCOLL_NON_TRACKING_ELEMENTS = []
 
-if xc.fluka.environment.ready:
+if xc.fluka.interface.ready:
     XCOLL_NON_TRACKING_ELEMENTS += [xc.FlukaCollimator, xc.FlukaCrystal]
-if xc.geant4.environment.ready:
+if xc.geant4.interface.ready:
     XCOLL_NON_TRACKING_ELEMENTS += [xc.Geant4Collimator, xc.Geant4CollimatorTip]
 
 EXTRA_XCOLL_ELEMENTS = []

--- a/xcoll/scattering_routines/engine.py
+++ b/xcoll/scattering_routines/engine.py
@@ -51,7 +51,7 @@ class BaseEngine(xo.HybridClass):
         self._masses = None
         self._verbose = False
         self._input_file = None
-        self._environment = None
+        self._interface = None
         self._element_dict = {}
         self._warning_given = False
         self._element_index = 0
@@ -68,7 +68,7 @@ class BaseEngine(xo.HybridClass):
 
     def _warn(self, error=None):
         if not self._warning_given:
-            print(f"Warning: Failed to import {self.__class__.__name__} environment "
+            print(f"Warning: Failed to import {self.__class__.__name__} interface "
                 + f"(did you compile?).\n{self.name.capitalize()} elements can be installed "
                 + f"but are not trackable.", flush=True)
             self._warning_given = True
@@ -87,12 +87,12 @@ class BaseEngine(xo.HybridClass):
     # ==================
 
     @property
-    def environment(self):
-        if self._environment is None:
-            raise RuntimeError(f"{self.__class__.__name__} environment not set up! "
+    def interface(self):
+        if self._interface is None:
+            raise RuntimeError(f"{self.__class__.__name__} interface not set up! "
                              + f"Do not manually create an instance of the engine, but use "
                              + f"xcoll.{self.__class__.__name__}.engine instead.")
-        return self._environment
+        return self._interface
 
     @property
     def name(self):
@@ -264,11 +264,11 @@ class BaseEngine(xo.HybridClass):
         return self._physics_settings.show()
 
     def start(self, *, clean=True, input_file=None, **kwargs):
-        if not self.environment:
+        if not self.interface:
             self.stop()
-            raise RuntimeError(f"{self.name.capitalize()} environment not set up! "
+            raise RuntimeError(f"{self.name.capitalize()} interface not set up! "
                              + f"Do not manually create an instance of the engine.")
-        self.environment.assert_environment_ready()
+        self.interface.assert_environment_ready()
         if self.is_running():
             self._print("Engine already running.")
             return
@@ -333,7 +333,7 @@ class BaseEngine(xo.HybridClass):
         self._starting_or_stopping = False
         self._warning_given = False
         self._tracking_initialised = False
-        self._environment.restore_environment()
+        self.interface.restore_environment()
 
     def is_running(self):
         if hasattr(self, '_starting_or_stopping') and self._starting_or_stopping:
@@ -422,10 +422,10 @@ class BaseEngine(xo.HybridClass):
             self.stop()
             raise ValueError(f"{self.__class__.__name__} only supports CPU contexts!")
 
-        if not self.environment.compiled:
+        if not self.interface.compiled:
             self.stop()
-            raise RuntimeError(f"{self.__class__.__name__} environment not compiled! "
-                                + f"Please compile the environment before tracking.")
+            raise RuntimeError(f"{self.__class__.__name__} interface not compiled! "
+                                + f"Please compile the interface before tracking.")
 
         if not self.is_running():
             self.stop()

--- a/xcoll/scattering_routines/environment.py
+++ b/xcoll/scattering_routines/environment.py
@@ -7,19 +7,51 @@ import os
 import sys
 import json
 import tempfile
+import getpass
 from subprocess import run, PIPE
 # from platformdirs import user_config_dir, user_data_dir
 
 from ..general import _pkg_root
+from pathlib import Path
 try:
     from xaux import FsPath  # TODO: once xaux is in Xsuite keep only this
 except (ImportError, ModuleNotFoundError):
     from ..xaux import FsPath
 
+def _is_writable_directory(path: str | Path) -> bool:
+    directory = Path(path).expanduser()
+
+    if not directory.is_dir():
+        return False
+
+    try:
+        with tempfile.TemporaryFile(dir=directory):
+            pass
+        return True
+    except OSError:
+        return False
+
+def _select_directory_for_config_and_data(preferred: str | Path) -> Path:
+    candidates = [
+        Path(preferred).expanduser(),
+        Path.home(),
+        Path(tempfile.gettempdir()),
+    ]
+    # Prefer persistent directory, if nothing available, use /tmp
+    for directory in candidates:
+        if _is_writable_directory(directory):
+            if directory == Path(tempfile.gettempdir()):
+                return directory.joinpath(getpass.getuser())
+            else:
+                return directory
+
+    raise RuntimeError("No writable directory was found.")
+
+_config_and_data_root = _select_directory_for_config_and_data(_pkg_root).joinpath(".xcoll")
 
 class BaseEnvironment:
-    _config_dir = FsPath(_pkg_root / 'config').resolve()
-    _data_dir   = FsPath(_pkg_root / 'lib').resolve()
+    _config_dir = FsPath(_config_and_data_root / 'config').resolve()
+    _data_dir   = FsPath(_config_and_data_root / 'lib').resolve()
     # _config_dir = FsPath(user_config_dir('xcoll')).resolve()
     # _data_dir   = FsPath(user_data_dir('xcoll')).resolve()
     _paths = {} # The value is the parent depth that needs to be brute-forced (0 = file itself, None = no brute-force)

--- a/xcoll/scattering_routines/fluka/engine.py
+++ b/xcoll/scattering_routines/fluka/engine.py
@@ -138,7 +138,7 @@ class FlukaEngine(BaseEngine):
     def view(self):
         if self.input_file is None:
             return
-        self.environment.run_flair(self.input_file[0])
+        self.interface.run_flair(self.input_file[0])
 
 
     # =================================
@@ -162,8 +162,8 @@ class FlukaEngine(BaseEngine):
 
     def _pre_start(self, **kwargs):
         import xcoll as xc
-        xc.fluka.environment.assert_gfortran_installed()
-        xc.fluka.environment.set_fluka_environment()
+        xc.fluka.interface.assert_gfortran_installed()
+        xc.fluka.interface.set_fluka_environment()
         return kwargs
 
 
@@ -206,7 +206,7 @@ class FlukaEngine(BaseEngine):
             self.stop()
             return False
         try:
-            rprocs = self.environment.running_processes()
+            rprocs = self.interface.running_processes()
         except RuntimeError as e:
             self.stop()
             raise RuntimeError from e
@@ -414,9 +414,9 @@ class FlukaEngine(BaseEngine):
         log = self.cwd / server_log
         self._log = log
         self._log_fid = self._log.open('w')
-        cmds = [xc.fluka.environment.fluka.as_posix(),
+        cmds = [xc.fluka.interface.fluka.as_posix(),
                 self.input_file[0].as_posix(), '-e',
-                xc.fluka.environment.flukaserver.as_posix(), '-M', "1"]
+                xc.fluka.interface.flukaserver.as_posix(), '-M', "1"]
         self._print(f"Running `{' '.join(cmds)}` in folder {self._cwd}...")
         self._server_process = Popen(cmds, cwd=self.cwd, stdout=self._log_fid, stderr=self._log_fid)
         self.server_pid = self._server_process.pid

--- a/xcoll/scattering_routines/fluka/environment.py
+++ b/xcoll/scattering_routines/fluka/environment.py
@@ -13,7 +13,7 @@ try:
 except (ImportError, ModuleNotFoundError):
     from ...xaux import FsPath
 
-from ..environment import BaseEnvironment
+from ...package_env import BaseEnvironment
 from ...general import _pkg_root
 
 
@@ -127,16 +127,16 @@ class FlukaEnvironment(BaseEnvironment):
                                f"Error given is:\n{stderr}")
         os.chdir(cwd)
         # Collect the compiled shared library
-        so = list((self.temp_dir / 'FORTRAN_src' / 'build').glob('pyflukaf.*so'))
+        so = list((dest / 'build').glob('pyflukaf.*so'))
         if len(so) > 1:
             raise RuntimeError(f"Compiled into multiple pyflukaf shared libraries!")
         if len(so) == 0:
-            raise RuntimeError(f"Failed pyFLUKA compilation! No shared library found in "
-                             + f"{self.data_dir.as_posix()}!")
+            raise RuntimeError(f"Failed pyFLUKA compilation! No shared library"
+                               f" found in {dest / 'build'}!")
         so = so[0]
-        so.move_to(self.data_dir / so.name)
+        so.move_to(self.lib_dir / so.name)
         if verbose:
-            print(f"Created pyFLUKA shared library in {so}.")
+            print(f"Created pyFLUKA shared library in {self.lib_dir / so.name}.")
         # Clean up the temporary directory
         self.temp_dir = None
         self.restore_environment()

--- a/xcoll/scattering_routines/fluka/environment.py
+++ b/xcoll/scattering_routines/fluka/environment.py
@@ -13,7 +13,7 @@ try:
 except (ImportError, ModuleNotFoundError):
     from ...xaux import FsPath
 
-from ...package_env import BaseEnvironment
+from ...package_env import BaseInterface
 from ...general import _pkg_root
 
 
@@ -21,7 +21,7 @@ _FORTRAN_SRC   = FsPath(_pkg_root / 'scattering_routines' / 'fluka' / 'FORTRAN_s
 _FEDB_TEMPLATE = FsPath(_pkg_root / 'scattering_routines' / 'fluka' / 'fedb').resolve()
 
 
-class FlukaEnvironment(BaseEnvironment):
+class FlukaInterface(BaseInterface):
     # The paths to be set. The value is the parent depth that needs to be brute-forced (0 = file itself, None = no brute-force)
     _paths = {'fluka': 2, 'flukaserver': 1, 'linebuilder': 0}
     _optional_paths = {'flair': 1}
@@ -34,7 +34,7 @@ class FlukaEnvironment(BaseEnvironment):
 
     @property
     def fedb(self):
-        return self._data_dir / 'fedb'
+        return self.data_dir / 'fedb'
 
     @property
     def compiled(self):

--- a/xcoll/scattering_routines/fluka/fluka_input.py
+++ b/xcoll/scattering_routines/fluka/fluka_input.py
@@ -48,7 +48,7 @@ def create_fluka_input(element_dict, particle_ref, prototypes_file=None,
             if assm.material is not None:
                 if assm.material.fluka_name is None or assm.material.fluka_name.startswith('XCOLL'):
                     assm.material._generate_fluka_code()
-        fedb = xc.fluka.environment.create_temp_fedb(assemblies)
+        fedb = xc.fluka.interface.create_temp_fedb(assemblies)
         _create_prototypes_file(element_dict, prototypes_file)
         _, kwargs = get_include_files(particle_ref, verbose=verbose, **kwargs)
     except Exception as e:
@@ -198,8 +198,8 @@ def _element_dict_to_fluka(element_dict, dump=False):
 def _fluka_builder(collimator_dict, fedb):
     import xcoll as xc
     # Save system state
-    xc.fluka.environment.set_fedb_environment(fedb)
-    file_path = xc.fluka.environment.linebuilder / "src" / "FLUKA_builder.py"
+    xc.fluka.interface.set_fedb_environment(fedb)
+    file_path = xc.fluka.interface.linebuilder / "src" / "FLUKA_builder.py"
     if file_path.exists():
         try:
             import FLUKA_builder as fb
@@ -223,7 +223,7 @@ def _fluka_builder(collimator_dict, fedb):
             input_file, coll_dict = fb.fluka_builder(args_fb, auto_accept=True)
 
     # Restore system state
-    xc.fluka.environment.restore_environment()
+    xc.fluka.interface.restore_environment()
 
     return input_file, coll_dict
 

--- a/xcoll/scattering_routines/fluka/prototype.py
+++ b/xcoll/scattering_routines/fluka/prototype.py
@@ -167,7 +167,7 @@ class FlukaPrototype:
                     file.unlink()
                 except FileNotFoundError:
                     pass
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         meta = fedb / "metadata" / f'{self.fedb_series}_{self.fedb_tag}.bodies.json'
         if meta.exists() or meta.is_symlink():
             try:
@@ -271,7 +271,7 @@ class FlukaPrototype:
             return None
         if self.is_generic():
             return self._generic_body_file
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         file = fedb / "bodies" / f"{self.fedb_series}_{self.fedb_tag}.bodies"
         return file.resolve()
 
@@ -288,7 +288,7 @@ class FlukaPrototype:
         path = FsPath(path)
         if not path.exists():
             raise FileNotFoundError(f"File {path} does not exist!")
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         target = fedb / "bodies" / f"{self.fedb_series}_{self.fedb_tag}.bodies"
         if path != target:
             path.copy_to(target, method='mount')
@@ -302,7 +302,7 @@ class FlukaPrototype:
             return None
         if self.is_generic():
             return self._generic_material_file
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         file = fedb / "materials" / f"{self.fedb_series}_{self.fedb_tag}.assignmat"
         return file.resolve()
 
@@ -319,7 +319,7 @@ class FlukaPrototype:
         path = FsPath(path)
         if not path.exists():
             raise FileNotFoundError(f"File {path} does not exist!")
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         path.copy_to(fedb / "materials" / f"{self.fedb_series}_{self.fedb_tag}.assignmat",
                      method='mount')
 
@@ -330,7 +330,7 @@ class FlukaPrototype:
             return None
         if self.is_generic():
             return self._generic_region_file
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         file = fedb / "regions" / f"{self.fedb_series}_{self.fedb_tag}.regions"
         return file.resolve()
 
@@ -347,7 +347,7 @@ class FlukaPrototype:
         path = FsPath(path)
         if not path.exists():
             raise FileNotFoundError(f"File {path} does not exist!")
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         path.copy_to(fedb / "regions" / f"{self.fedb_series}_{self.fedb_tag}.regions",
                      method='mount')
 
@@ -674,7 +674,7 @@ class FlukaPrototype:
     def view(self, show=True, keep_files=False):
         import xcoll as xc
         if self.exists():
-            xc.fluka.environment.test_assembly(self.fedb_series, self.fedb_tag, show=show,
+            xc.fluka.interface.test_assembly(self.fedb_series, self.fedb_tag, show=show,
                                                keep_files=keep_files)
 
 
@@ -711,7 +711,7 @@ class FlukaAssembly(FlukaPrototype):
                 self.assembly_file.unlink()
             except FileNotFoundError:
                 pass
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         meta = fedb / "metadata" / f'{self.fedb_series}_{self.fedb_tag}.lbp.json'
         if meta.exists() or meta.is_symlink():
             meta.unlink()
@@ -723,7 +723,7 @@ class FlukaAssembly(FlukaPrototype):
             return None
         if self.is_generic():
             return self._generic_assembly_file
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         file = fedb / "assemblies" / f"{self.fedb_series}_{self.fedb_tag}.lbp"
         return file.resolve()
 
@@ -740,7 +740,7 @@ class FlukaAssembly(FlukaPrototype):
         path = FsPath(path)
         if not path.exists():
             raise FileNotFoundError(f"File {path} does not exist!")
-        fedb = xc.fluka.environment.fedb
+        fedb = xc.fluka.interface.fedb
         target = fedb / "assemblies" / f"{self.fedb_series}_{self.fedb_tag}.lbp"
         if path != target:
             path.copy_to(target, method='mount')

--- a/xcoll/scattering_routines/fluka/wrapper.py
+++ b/xcoll/scattering_routines/fluka/wrapper.py
@@ -14,7 +14,7 @@ from .reference_masses import fluka_masses_meta
 from .reference_names import fluka_names_meta
 from .prototype import FlukaPrototypeAccessor, FlukaAssemblyAccessor
 from .engine import FlukaEngine
-from .environment import FlukaEnvironment
+from .environment import FlukaInterface
 from ..wrapper import BaseWrapper
 
 
@@ -22,18 +22,18 @@ class FlukaWrapper(BaseWrapper):
     """Wrapper for all FLUKA functions."""
 
     _engine_cls = FlukaEngine
-    _environment_cls = FlukaEnvironment
+    _interface_cls = FlukaInterface
     _particle_masses_meta = fluka_masses_meta
     _particle_names_meta = fluka_names_meta
 
     @property
     def assemblies(self):
-        self._lazy_load_environment()
+        self._lazy_load_interface()
         return FlukaAssemblyAccessor()
 
     @property
     def prototypes(self):
-        self._lazy_load_environment()
+        self._lazy_load_interface()
         return FlukaPrototypeAccessor()
 
     def view(self, elements=None, *, input_file=None):
@@ -46,9 +46,9 @@ class FlukaWrapper(BaseWrapper):
             raise ValueError("Either elements or input_file must be provided!")
         if not hasattr(input_file, '__iter__') or isinstance(input_file, (str, io.IOBase)):
             input_file = [input_file]
-        self.environment.run_flair(input_file[0])
+        self.interface.run_flair(input_file[0])
         if elements:
             # Input file was generated from elements, so we can remove it
             for f in input_file:
                 if FsPath(f).exists():
-                    f.unlink()
+                    FsPath(f).unlink()

--- a/xcoll/scattering_routines/geant4/environment.py
+++ b/xcoll/scattering_routines/geant4/environment.py
@@ -7,7 +7,7 @@ import os
 import requests
 from subprocess import run
 
-from ...package_env import BaseEnvironment
+from ...package_env import BaseInterface
 from ...general import _pkg_root
 try:
     from xaux import FsPath  # TODO: once xaux is in Xsuite keep only this
@@ -15,7 +15,7 @@ except (ImportError, ModuleNotFoundError):
     from ...xaux import FsPath
 
 
-class Geant4Environment(BaseEnvironment):
+class Geant4Interface(BaseInterface):
     _read_only_paths = {'bdsim': 0, 'geant4': 0}
 
     def __init__(self):

--- a/xcoll/scattering_routines/geant4/environment.py
+++ b/xcoll/scattering_routines/geant4/environment.py
@@ -4,11 +4,10 @@
 # ######################################### #
 
 import os
-import sys
 import requests
 from subprocess import run
 
-from ..environment import BaseEnvironment
+from ...package_env import BaseEnvironment
 from ...general import _pkg_root
 try:
     from xaux import FsPath  # TODO: once xaux is in Xsuite keep only this
@@ -135,12 +134,12 @@ class Geant4Environment(BaseEnvironment):
         if len(so) > 1:
             raise RuntimeError(f"Compiled into multiple g4interface shared libraries!")
         if len(so) == 0:
-            raise RuntimeError(f"Failed Xcoll-BDSIM compilation! No shared library found in "
-                             + f"{self.data_dir.as_posix()}!")
+            raise RuntimeError(f"Failed Xcoll-BDSIM compilation! No shared "
+                               f"library found in {dest / 'build'}!")
         so = FsPath(so[0])
-        so.move_to(self.data_dir / so.name)
+        so.move_to(self.lib_dir / so.name)
         if verbose:
-            print(f"Created Xcoll-BDSIM shared library in {self.data_dir / so.name}.")
+            print(f"Created Xcoll-BDSIM shared library in {self.lib_dir / so.name}.")
         # Clean up the temporary directory
         self.temp_dir = None
         os.chdir(cwd)

--- a/xcoll/scattering_routines/geant4/wrapper.py
+++ b/xcoll/scattering_routines/geant4/wrapper.py
@@ -5,7 +5,7 @@
 
 from ..wrapper import BaseWrapper
 from .engine import Geant4Engine
-from .environment import Geant4Environment
+from .environment import Geant4Interface
 from .reference_masses import geant4_masses_meta
 
 
@@ -13,5 +13,5 @@ class Geant4Wrapper(BaseWrapper):
     """Wrapper for all Geant4 and BDSIM functions."""
 
     _engine_cls = Geant4Engine
-    _environment_cls = Geant4Environment
+    _interface_cls = Geant4Interface
     _particle_masses_meta = geant4_masses_meta

--- a/xcoll/scattering_routines/wrapper.py
+++ b/xcoll/scattering_routines/wrapper.py
@@ -7,13 +7,13 @@ import xtrack.particles.pdg as pdg
 
 class BaseWrapper:
     _engine_cls = None
-    _environment_cls = None
+    _interface_cls = None
     _particle_masses_meta = None
     _particle_names_meta = None
 
     def __init__(self):
         self._engine = None
-        self._environment = None
+        self._interface = None
 
     def __str__(self):
         return f"{self.__class__.__name__}"
@@ -27,9 +27,14 @@ class BaseWrapper:
         return self._engine
 
     @property
+    def interface(self):
+        self._lazy_load_interface()
+        return self._interface
+
+    @property
     def environment(self):
-        self._lazy_load_environment()
-        return self._environment
+        print("WARNING: .environment is deprecated. Use .interface instead.")
+        return self.interface
 
     @property
     def particle_masses(self):
@@ -45,16 +50,16 @@ class BaseWrapper:
                 "This wrapper does not implement particle_names.")
         return BaseWrapperAccessor(self._particle_names_meta)
 
-    def _lazy_load_environment(self):
-        # Ensure the environment is loaded
-        if not self._environment:
-            self._environment = self._environment_cls()
+    def _lazy_load_interface(self):
+        # Ensure the interface is loaded
+        if not self._interface:
+            self._interface = self._interface_cls()
 
     def _lazy_load_engine(self):
         # Ensure the engine is loaded
         if not self._engine:
             self._engine = self._engine_cls()
-            self._engine._environment = self.environment
+            self._engine._interface = self.interface
             if self._particle_masses_meta is None:
                 self._engine._masses = None
             else:


### PR DESCRIPTION
- **Fix permission issues when xcoll is installed read-only**
- **Created release branch release/v0.11.6rc0.**
- **Updating environment to allow for paths to be set with an environment variable, and default to ~/.xcoll instead of inside the package folder**
- **Make the xobjects hook conditional**
- **Renamed BaseEnvironment etc as BaseInterface**
- **Typo**
- **Updated tests and examples to  use 'interface' instead of 'environment'**
- **Typo**
- **Updated version number to v0.11.6.**
